### PR TITLE
Napari rlv

### DIFF
--- a/command_line/napari_rlv.py
+++ b/command_line/napari_rlv.py
@@ -60,7 +60,7 @@ def run(args=None):
 
     reflections = reflections[0]
 
-    viewer = napari.Viewer(
+    napari_viewer = napari.Viewer(
         title=os.path.realpath(params.input.reflections[0].filename),
         ndisplay=3,
     )
@@ -70,15 +70,17 @@ def run(args=None):
         os.path.realpath(params.input.reflections[0].filename),
         size=(1024, 768),
         settings=copy.deepcopy(params),
+        napari_viewer=napari_viewer,
     )
     rlv.load_models(experiments, reflections)
-    rlv.add_to_napari(viewer)
+    rlv.add_rlv_widgets()
+    rlv.add_layers()
 
     # Set rotation around the origin
-    viewer.camera.center = (0, 0, 0)
+    napari_viewer.camera.center = (0, 0, 0)
 
     # Hide the layer controls - needs non-public access
-    # viewer.window._qt_viewer.dockLayerControls.setVisible(False)
+    # napari_viewer.window._qt_viewer.dockLayerControls.setVisible(False)
 
     napari.run()
 

--- a/command_line/napari_rlv.py
+++ b/command_line/napari_rlv.py
@@ -71,6 +71,9 @@ def run(args=None):
     rlv.load_models(experiments, reflections)
     rlv.add_to_napari(viewer)
 
+    # Hide the layer controls - needs non-public access
+    # viewer.window._qt_viewer.dockLayerControls.setVisible(False)
+
     napari.run()
 
 

--- a/command_line/napari_rlv.py
+++ b/command_line/napari_rlv.py
@@ -7,13 +7,16 @@ from __future__ import annotations
 import copy
 import os
 
-import napari
-
 from scitbx.array_family import flex
 
 import dials.util.log
 from dials.util.options import ArgumentParser, reflections_and_experiments_from_files
 from dials_scratch.dgw.rlv.viewer import ReciprocalLatticeViewer, phil_scope
+
+try:
+    import napari
+except ImportError:
+    napari = None
 
 help_message = """
 Visualise the strong spots from spotfinding in reciprocal space.
@@ -89,4 +92,6 @@ def run(args=None):
 
 
 if __name__ == "__main__":
+    if not napari:
+        sys.exit("Please install napari >= 0.4.16")
     run()

--- a/command_line/napari_rlv.py
+++ b/command_line/napari_rlv.py
@@ -60,7 +60,10 @@ def run(args=None):
 
     reflections = reflections[0]
 
-    viewer = napari.Viewer(ndisplay=3)
+    viewer = napari.Viewer(
+        title=os.path.realpath(params.input.reflections[0].filename),
+        ndisplay=3,
+    )
     rlv = ReciprocalLatticeViewer(
         None,
         -1,

--- a/command_line/napari_rlv.py
+++ b/command_line/napari_rlv.py
@@ -79,6 +79,9 @@ def run(args=None):
     # Set rotation around the origin
     napari_viewer.camera.center = (0, 0, 0)
 
+    # Make the last-added relps layer active rather than the rotation axis
+    napari_viewer.layers.selection.active = napari_viewer.layers[0]
+
     # Hide the layer controls - needs non-public access
     # napari_viewer.window._qt_viewer.dockLayerControls.setVisible(False)
 

--- a/command_line/napari_rlv.py
+++ b/command_line/napari_rlv.py
@@ -74,6 +74,9 @@ def run(args=None):
     rlv.load_models(experiments, reflections)
     rlv.add_to_napari(viewer)
 
+    # Set rotation around the origin
+    viewer.camera.center = (0, 0, 0)
+
     # Hide the layer controls - needs non-public access
     # viewer.window._qt_viewer.dockLayerControls.setVisible(False)
 

--- a/command_line/napari_rlv.py
+++ b/command_line/napari_rlv.py
@@ -74,7 +74,7 @@ def run(args=None):
     )
     rlv.load_models(experiments, reflections)
     rlv.add_rlv_widgets()
-    rlv.add_layers()
+    rlv.update_layers()
 
     # Set rotation around the origin
     napari_viewer.camera.center = (0, 0, 0)

--- a/command_line/napari_rlv.py
+++ b/command_line/napari_rlv.py
@@ -6,12 +6,15 @@ from __future__ import annotations
 
 import copy
 import os
+import sys
 
 from scitbx.array_family import flex
 
 import dials.util.log
 from dials.util.options import ArgumentParser, reflections_and_experiments_from_files
 from dials_scratch.dgw.rlv.viewer import ReciprocalLatticeViewer, phil_scope
+
+from packaging import version
 
 try:
     import napari
@@ -90,5 +93,8 @@ def run(args=None):
 
 if __name__ == "__main__":
     if not napari:
+        sys.exit("Please install napari")
+    if version.parse(napari.__version__) < version.parse("0.4.16"):
         sys.exit("Please install napari >= 0.4.16")
+
     run()

--- a/command_line/napari_rlv.py
+++ b/command_line/napari_rlv.py
@@ -85,9 +85,6 @@ def run(args=None):
     # Make the last-added relps layer active rather than the rotation axis
     napari_viewer.layers.selection.active = napari_viewer.layers[0]
 
-    # Hide the layer controls - needs non-public access
-    # napari_viewer.window._qt_viewer.dockLayerControls.setVisible(False)
-
     napari.run()
 
 

--- a/command_line/napari_rlv.py
+++ b/command_line/napari_rlv.py
@@ -1,0 +1,78 @@
+# LIBTBX_PRE_DISPATCHER_INCLUDE_SH export PHENIX_GUI_ENVIRONMENT=1
+# DIALS_ENABLE_COMMAND_LINE_COMPLETION
+# LIBTBX_SET_DISPATCHER_NAME dev.dials.napari_rlv
+
+from __future__ import annotations
+
+import copy
+import os
+
+import napari
+
+from scitbx.array_family import flex
+
+import dials.util.log
+from dials.util.options import ArgumentParser, reflections_and_experiments_from_files
+from dials_scratch.dgw.rlv.viewer import ReciprocalLatticeViewer, phil_scope
+
+help_message = """
+Visualise the strong spots from spotfinding in reciprocal space.
+
+Examples::
+
+  dev.dials.napari_rlv imported.expt strong.refl
+
+  dev.dials.napari_rlv indexed.expt indexed.refl
+"""
+
+
+@dials.util.show_mail_handle_errors()
+def run(args=None):
+    dials.util.log.print_banner()
+    usage = "dev.dials.napari_rlv [options] models.expt observations.refl"
+
+    parser = ArgumentParser(
+        usage=usage,
+        phil=phil_scope,
+        read_experiments=True,
+        read_reflections=True,
+        check_format=False,
+        epilog=help_message,
+    )
+
+    params, options = parser.parse_args(args, show_diff_phil=True)
+    reflections, experiments = reflections_and_experiments_from_files(
+        params.input.reflections, params.input.experiments
+    )
+
+    if len(experiments) == 0 or len(reflections) == 0:
+        parser.print_help()
+        exit(0)
+
+    if len(reflections) > 1:
+        assert len(reflections) == len(experiments)
+        for i in range(len(reflections)):
+            reflections[i]["imageset_id"] = flex.int(len(reflections[i]), i)
+            if i > 0:
+                reflections[0].extend(reflections[i])
+    elif "imageset_id" not in reflections[0]:
+        reflections[0]["imageset_id"] = reflections[0]["id"]
+
+    reflections = reflections[0]
+
+    viewer = napari.Viewer(ndisplay=3)
+    rlv = ReciprocalLatticeViewer(
+        None,
+        -1,
+        os.path.realpath(params.input.reflections[0].filename),
+        size=(1024, 768),
+        settings=copy.deepcopy(params),
+    )
+    rlv.load_models(experiments, reflections)
+    rlv.add_to_napari(viewer)
+
+    napari.run()
+
+
+if __name__ == "__main__":
+    run()

--- a/dgw/rlv/__init__.py
+++ b/dgw/rlv/__init__.py
@@ -1,0 +1,299 @@
+from __future__ import annotations
+
+import copy
+
+import libtbx.phil
+from scitbx import matrix
+
+from dials.array_family import flex
+
+phil_scope = libtbx.phil.parse(
+    """
+reverse_phi = False
+  .type = bool
+  .optional = True
+crystal_frame = False
+  .type = bool
+  .optional = True
+beam_centre_panel = None
+  .type = int
+  .help = "Panel number for the beam centre"
+beam_centre = None
+  .type = floats(size=2)
+  .help = "Fast, slow beam centre coordinates (mm)."
+d_min = None
+  .type = float(value_min=0.0)
+z_min = None
+  .type = float
+z_max = None
+  .type = float
+n_min = 0
+  .type = int
+  .help = "Minimum size of spot in pixels"
+n_max = 1000000
+  .type = int
+  .help = "Maximum size of spot in pixels"
+partiality_min = None
+  .type = float
+partiality_max = None
+  .type = float
+display = *all unindexed indexed integrated
+  .type = choice
+outlier_display = outliers inliers
+  .type = choice
+experiment_ids = None
+  .type = ints(value_min=-1)
+black_background = True
+  .type = bool
+  .help = "Switch between black or white background"
+"""
+)
+
+
+class Render3d:
+    def __init__(self, settings=None):
+        self.reflections = None
+        if settings is None:
+            self.settings = phil_scope.fetch().extract()
+        else:
+            self.settings = settings
+        self.goniometer_orig = None
+        self.viewer = None
+
+    def load_models(self, experiments, reflections):
+        self.experiments = experiments
+        self.reflections_input = reflections
+        if self.experiments[0].goniometer is not None:
+            self.viewer.set_rotation_axis(
+                self.experiments[0].goniometer.get_rotation_axis()
+            )
+        self.viewer.set_beam_vector(self.experiments[0].beam.get_s0())
+        if self.settings.beam_centre is None:
+            try:
+                (
+                    self.settings.beam_centre_panel,
+                    self.settings.beam_centre,
+                ) = self.experiments[0].detector.get_ray_intersection(
+                    self.experiments[0].beam.get_s0()
+                )
+            except RuntimeError:
+                pass
+        else:
+            self.set_beam_centre(
+                self.settings.beam_centre_panel, self.settings.beam_centre
+            )
+        crystals = [
+            expt.crystal for expt in self.experiments if expt.crystal is not None
+        ]
+        if crystals:
+            # the points are scaled by 100 so must do that here too
+            vecs = [
+                [
+                    matrix.col(l)
+                    for l in (100 * matrix.sqr(c.get_A()))
+                    .transpose()
+                    .as_list_of_lists()
+                ]
+                for c in crystals
+            ]
+            self.viewer.set_reciprocal_lattice_vectors(vecs)
+            vecs = [
+                [
+                    matrix.col(l)
+                    for l in (100 * matrix.sqr(c.get_B()))
+                    .transpose()
+                    .as_list_of_lists()
+                ]
+                for c in crystals
+            ]
+            self.viewer.set_reciprocal_crystal_vectors(vecs)
+        self.map_points_to_reciprocal_space()
+        self.set_points()
+
+    def map_points_to_reciprocal_space(self):
+        # 155 handle data from predictions *only* if that is what we have
+        calculated = "xyzobs.px.value" not in self.reflections_input
+        self.reflections = copy.deepcopy(self.reflections_input)
+        experiments = copy.deepcopy(self.experiments)
+
+        if not calculated:
+            self.reflections.centroid_px_to_mm(experiments)
+
+        if self.settings.reverse_phi:
+            for expt in experiments:
+                expt.goniometer.set_rotation_axis(
+                    [-i for i in expt.goniometer.get_rotation_axis()]
+                )
+
+        self.reflections.map_centroids_to_reciprocal_space(
+            experiments,
+            calculated=calculated,
+            crystal_frame=self.settings.crystal_frame,
+        )
+
+    def set_points(self):
+        reflections = self.reflections
+
+        if "miller_index" in reflections:
+            if "flags" not in reflections:
+                reflections.set_flags(
+                    reflections["miller_index"] != (0, 0, 0), reflections.flags.indexed
+                )
+                reflections["id"].set_selected(
+                    reflections["miller_index"] == (0, 0, 0), -1
+                )
+                reflections.set_flags(
+                    flex.bool(len(reflections), True), reflections.flags.strong
+                )
+                reflections.set_flags(
+                    flex.bool(len(reflections), False), reflections.flags.integrated
+                )
+                reflections.set_flags(
+                    flex.bool(len(reflections), False),
+                    reflections.flags.centroid_outlier,
+                )
+
+            outlier_sel = reflections.get_flags(reflections.flags.centroid_outlier)
+
+            if self.settings.outlier_display == "outliers":
+                reflections = reflections.select(outlier_sel)
+            if self.settings.outlier_display == "inliers":
+                reflections = reflections.select(~outlier_sel)
+
+            indexed_sel = reflections.get_flags(reflections.flags.indexed)
+            strong_sel = reflections.get_flags(reflections.flags.strong)
+            integrated_sel = reflections.get_flags(reflections.flags.integrated)
+
+            if self.settings.display == "indexed":
+                reflections = reflections.select(indexed_sel)
+            elif self.settings.display == "unindexed":
+                reflections = reflections.select(strong_sel & ~indexed_sel)
+            elif self.settings.display == "integrated":
+                reflections = reflections.select(integrated_sel)
+
+            if self.settings.experiment_ids:
+                sel = flex.bool(len(reflections), False)
+                for i in self.settings.experiment_ids:
+                    sel.set_selected(reflections["id"] == i, True)
+                reflections = reflections.select(sel)
+
+        d_spacings = 1 / reflections["rlp"].norms()
+
+        # 155 handle data from predictions *only* if that is what we have
+        if "xyzobs.px.value" in self.reflections_input:
+            use_column = "xyzobs.px.value"
+        else:
+            use_column = "xyzcal.px"
+
+        if self.settings.d_min is not None:
+            reflections = reflections.select(d_spacings >= self.settings.d_min)
+        else:
+            self.settings.d_min = flex.min(d_spacings)
+        if self.settings.z_min is not None:
+            z = reflections[use_column].parts()[2]
+            reflections = reflections.select(z >= self.settings.z_min)
+        else:
+            z = reflections[use_column].parts()[2]
+            self.settings.z_min = flex.min(z)
+        if self.settings.z_max is not None:
+            z = reflections[use_column].parts()[2]
+            reflections = reflections.select(z <= self.settings.z_max)
+        else:
+            z = reflections[use_column].parts()[2]
+            self.settings.z_max = flex.max(z)
+
+        if "n_signal" in reflections:
+            if self.settings.n_min is not None:
+                _ns = reflections["n_signal"]
+                reflections = reflections.select(_ns >= self.settings.n_min)
+            else:
+                _ns = reflections["n_signal"]
+                self.settings.n_min = int(flex.min(_ns))
+
+            if self.settings.n_max is not None:
+                _ns = reflections["n_signal"]
+                reflections = reflections.select(_ns <= self.settings.n_max)
+            else:
+                _ns = reflections["n_signal"]
+                self.settings.n_max = int(flex.max(_ns))
+
+        if "partiality" in reflections:
+            p = reflections["partiality"]
+            if self.settings.partiality_min is not None:
+                sel = p >= self.settings.partiality_min
+                reflections = reflections.select(sel)
+                p = p.select(sel)
+            else:
+                self.settings.partiality_min = flex.min(p)
+            if self.settings.partiality_max is not None:
+                reflections = reflections.select(p <= self.settings.partiality_max)
+            else:
+                self.settings.partiality_max = flex.max(p)
+        points = reflections["rlp"] * 100
+        self.viewer.set_points(points)
+        self.viewer.set_points_data(reflections)
+        colors = flex.vec3_double(len(points), (1, 1, 1))
+
+        if len(points):
+            # suggested colorblind color palette
+            # sorry if you have > 8 lattices!
+            palette = flex.vec3_double(
+                (
+                    (255, 255, 255),
+                    (230, 159, 0),
+                    (86, 180, 233),
+                    (0, 158, 115),
+                    (240, 228, 66),
+                    (0, 114, 178),
+                    (213, 94, 0),
+                    (204, 121, 167),
+                )
+            )
+            palette *= 1 / 255
+            if not self.settings.black_background:
+                bkg = flex.vec3_double()
+                for j in range(len(palette)):
+                    bkg.append((1, 1, 1))
+                palette = bkg - palette
+            self.viewer.set_palette(palette)
+            n = palette.size() - 1
+            if (
+                self.reflections.get_flags(self.reflections.flags.indexed).count(True)
+                == 0
+            ):
+                if "imageset_id" in reflections:
+                    imageset_id = reflections["imageset_id"]
+                else:
+                    imageset_id = reflections["id"]
+                for i in range(0, flex.max(imageset_id) + 1):
+                    colors.set_selected(imageset_id == i, palette[(i % n) + 1])
+            else:
+                colors.set_selected(reflections["id"] == -1, palette[0])
+                for i in range(0, flex.max(reflections["id"]) + 1):
+                    colors.set_selected(reflections["id"] == i, palette[(i % n) + 1])
+        self.viewer.set_colors(colors)
+
+    def set_beam_centre(self, panel, beam_centre):
+        detector = self.experiments[0].detector
+        beam = self.experiments[0].beam
+        panel = int(panel)
+
+        try:
+            p = detector[panel]
+        except RuntimeError:
+            raise ValueError(f"Detector does not have panel index {panel}")
+
+        # Check if the new beam centre can be set
+        beam_f, beam_s = beam_centre
+        trial_s0_direction = p.get_lab_coord((beam_f, beam_s))
+        try:
+            panel_id, beam_centre = detector.get_ray_intersection(trial_s0_direction)
+        except RuntimeError:
+            # beam centre calculation fails if the beam falls between panels
+            raise ValueError("No detector intersection")
+
+        if panel_id != panel:
+            raise ValueError(f"Beam centre cannot be set with panel {panel}")
+
+        # If we get this far, then the beam centre is valid for this panel
+        beam.set_unit_s0(trial_s0_direction)

--- a/dgw/rlv/__init__.py
+++ b/dgw/rlv/__init__.py
@@ -59,6 +59,8 @@ class Render3d:
             self.settings = settings
         self.goniometer_orig = None
         self.viewer = None
+        # Suitable scale factor to use typical point and edge sizes
+        self._scale_factor = 1000
 
     def load_models(self, experiments, reflections):
         self.experiments = experiments
@@ -86,11 +88,10 @@ class Render3d:
             expt.crystal for expt in self.experiments if expt.crystal is not None
         ]
         if crystals:
-            # the points are scaled by 100 so must do that here too
             vecs = [
                 [
                     matrix.col(l)
-                    for l in (100 * matrix.sqr(c.get_A()))
+                    for l in (self._scale_factor * matrix.sqr(c.get_A()))
                     .transpose()
                     .as_list_of_lists()
                 ]
@@ -100,7 +101,7 @@ class Render3d:
             vecs = [
                 [
                     matrix.col(l)
-                    for l in (100 * matrix.sqr(c.get_B()))
+                    for l in (self._scale_factor * matrix.sqr(c.get_B()))
                     .transpose()
                     .as_list_of_lists()
                 ]
@@ -229,7 +230,7 @@ class Render3d:
                 reflections = reflections.select(p <= self.settings.partiality_max)
             else:
                 self.settings.partiality_max = flex.max(p)
-        points = reflections["rlp"] * 100
+        points = reflections["rlp"] * self._scale_factor
         self.viewer.set_points(points)
         self.viewer.set_points_data(reflections)
         colors = flex.vec3_double(len(points), (1, 1, 1))

--- a/dgw/rlv/__init__.py
+++ b/dgw/rlv/__init__.py
@@ -58,7 +58,7 @@ class Render3d:
         else:
             self.settings = settings
         self.goniometer_orig = None
-        self.viewer = None
+        self.rlv_window = None
         # Suitable scale factor to use typical point and edge sizes
         self._scale_factor = 1000
 
@@ -66,10 +66,10 @@ class Render3d:
         self.experiments = experiments
         self.reflections_input = reflections
         if self.experiments[0].goniometer is not None:
-            self.viewer.set_rotation_axis(
+            self.rlv_window.set_rotation_axis(
                 self.experiments[0].goniometer.get_rotation_axis()
             )
-        self.viewer.set_beam_vector(self.experiments[0].beam.get_s0())
+        self.rlv_window.set_beam_vector(self.experiments[0].beam.get_s0())
         if self.settings.beam_centre is None:
             try:
                 (
@@ -97,7 +97,7 @@ class Render3d:
                 ]
                 for c in crystals
             ]
-            self.viewer.set_reciprocal_lattice_vectors(vecs)
+            self.rlv_window.set_reciprocal_lattice_vectors(vecs)
             vecs = [
                 [
                     matrix.col(l)
@@ -107,7 +107,7 @@ class Render3d:
                 ]
                 for c in crystals
             ]
-            self.viewer.set_reciprocal_crystal_vectors(vecs)
+            self.rlv_window.set_reciprocal_crystal_vectors(vecs)
         self.map_points_to_reciprocal_space()
         self.set_points()
 
@@ -231,8 +231,8 @@ class Render3d:
             else:
                 self.settings.partiality_max = flex.max(p)
         points = reflections["rlp"] * self._scale_factor
-        self.viewer.set_points(points)
-        self.viewer.set_points_data(reflections)
+        self.rlv_window.set_points(points)
+        self.rlv_window.set_points_data(reflections)
         colors = flex.vec3_double(len(points), (1, 1, 1))
 
         if len(points):
@@ -256,7 +256,7 @@ class Render3d:
                 for j in range(len(palette)):
                     bkg.append((1, 1, 1))
                 palette = bkg - palette
-            self.viewer.set_palette(palette)
+            self.rlv_window.set_palette(palette)
             n = palette.size() - 1
             if (
                 self.reflections.get_flags(self.reflections.flags.indexed).count(True)
@@ -272,7 +272,7 @@ class Render3d:
                 colors.set_selected(reflections["id"] == -1, palette[0])
                 for i in range(0, flex.max(reflections["id"]) + 1):
                     colors.set_selected(reflections["id"] == i, palette[(i % n) + 1])
-        self.viewer.set_colors(colors)
+        self.rlv_window.set_colors(colors)
 
     def set_beam_centre(self, panel, beam_centre):
         detector = self.experiments[0].detector

--- a/dgw/rlv/viewer.py
+++ b/dgw/rlv/viewer.py
@@ -119,22 +119,22 @@ class ReciprocalLatticeViewer(Render3d):
         s = self.viewer.minimum_covering_sphere
         scale = max(max(s.box_max()), abs(min(s.box_min())))
         axis = self.viewer.rotation_axis
-        line = np.array(
+        axis_line = np.array(
             [[0, 0, 0], [axis[0] * scale, axis[1] * scale, axis[2] * scale]]
         )
 
-        # Struggling to add these shapes individually to separate layers. Let's
-        # just accumulate all shapes and then add them all at once
-        shapes = [line]
-        edge_colors = [(1, 1, 1)]
-
         axis_layer = napari_viewer.add_shapes(
-            shapes,
+            [
+                axis_line,
+            ],
             shape_type="line",
             edge_width=0.1,
-            edge_color=edge_colors,
+            edge_color="white",
             name="axis",
         )
+
+        # Set rotation around the origin
+        napari_viewer.camera.center = (0, 0, 0)
 
         return
 

--- a/dgw/rlv/viewer.py
+++ b/dgw/rlv/viewer.py
@@ -40,11 +40,13 @@ model_view_matrix = None
 )
 
 
-@magicgui(auto_call=True)
-def rlv_settings(viewer: napari.Viewer, marker_size: float):
+@magicgui(auto_call=True, d_min={"label": "high resolution", "step": 0.05})
+def rlv_settings(viewer: napari.Viewer, marker_size: int, d_min: float):
     for layer in viewer.layers:
         if layer.name.startswith("relps"):
             layer.size[:] = marker_size
+            shown = layer.properties["res"] >= d_min
+            layer.shown = shown
             layer.refresh()
 
 
@@ -151,6 +153,7 @@ class ReciprocalLatticeViewer(Render3d):
         # Add the rlv_settings widget and set values
         napari_viewer.window.add_dock_widget(rlv_settings, name="rlv settings")
         rlv_settings.marker_size.value = self.settings.marker_size
+        rlv_settings.d_min.value = self.settings.d_min
 
         return
 

--- a/dgw/rlv/viewer.py
+++ b/dgw/rlv/viewer.py
@@ -40,7 +40,7 @@ model_view_matrix = None
 )
 
 
-@magicgui
+@magicgui(auto_call=True)
 def rlv_settings(viewer: napari.Viewer, marker_size: float):
     for layer in viewer.layers:
         if layer.name.startswith("relps"):

--- a/dgw/rlv/viewer.py
+++ b/dgw/rlv/viewer.py
@@ -41,11 +41,15 @@ model_view_matrix = None
 
 
 @magicgui(auto_call=True, d_min={"label": "high resolution", "step": 0.05})
-def rlv_settings(viewer: napari.Viewer, marker_size: int, d_min: float):
+def rlv_settings(
+    viewer: napari.Viewer, marker_size: int, d_min: float, z_min: int, z_max: int
+):
     for layer in viewer.layers:
         if layer.name.startswith("relps"):
             layer.size[:] = marker_size
             shown = layer.properties["res"] >= d_min
+            shown = shown & (layer.properties["z"] >= z_min)
+            shown = shown & (layer.properties["z"] <= z_max)
             layer.shown = shown
             layer.refresh()
 
@@ -150,10 +154,17 @@ class ReciprocalLatticeViewer(Render3d):
         # Set rotation around the origin
         napari_viewer.camera.center = (0, 0, 0)
 
-        # Add the rlv_settings widget and set values
+        # Add the rlv_settings widget and set values and limits
         napari_viewer.window.add_dock_widget(rlv_settings, name="rlv settings")
         rlv_settings.marker_size.value = self.settings.marker_size
         rlv_settings.d_min.value = self.settings.d_min
+        rlv_settings.d_min.min = self.settings.d_min
+        rlv_settings.z_min.value = self.settings.z_min
+        rlv_settings.z_min.min = self.settings.z_min
+        rlv_settings.z_min.max = self.settings.z_max
+        rlv_settings.z_max.value = self.settings.z_max
+        rlv_settings.z_max.min = self.settings.z_min
+        rlv_settings.z_max.max = self.settings.z_max
 
         return
 

--- a/dgw/rlv/viewer.py
+++ b/dgw/rlv/viewer.py
@@ -100,9 +100,6 @@ class ReciprocalLatticeViewer(Render3d):
     @magicgui(auto_call=True)
     def rlv_geometry(self, invert_rotation_axis: bool, crystal_frame: bool):
 
-        # Clear current layers
-        # self.napari_viewer.layers.clear()
-
         # Set values
         self.settings.reverse_phi = invert_rotation_axis
         self.settings.crystal_frame = crystal_frame
@@ -192,7 +189,7 @@ class ReciprocalLatticeViewer(Render3d):
                 "indexed_status": flumpy.to_numpy(indexed_status),
                 "integrated_status": flumpy.to_numpy(integrated_status),
             }
-            # text = "id:{} panel:{panel} xyz:{x}{y}{z} res:{res}Å"
+
             if "miller_index" in self.rlv_window.points_data and exp_id != -1:
                 h, k, l = (
                     self.rlv_window.points_data["miller_index"]
@@ -206,11 +203,6 @@ class ReciprocalLatticeViewer(Render3d):
                 point_properties["h"] = flumpy.to_numpy(h)
                 point_properties["k"] = flumpy.to_numpy(k)
                 point_properties["l"] = flumpy.to_numpy(l)
-            #    text += " hkl:{hkl}"
-            # Currently not adding the text= to the points as this displays for
-            # *every* point. Need a mouseover or tooltip instead. However, the
-            # property values are displayed in the status bar, when the relevant
-            # layer is selected
 
             layer_name = f"relps id: {exp_id}"
             if layer_name in self._rlv_layers:
@@ -342,7 +334,6 @@ class ReciprocalLatticeViewer(Render3d):
         self.set_beam_centre(self.settings.beam_centre_panel, self.settings.beam_centre)
         self.map_points_to_reciprocal_space()
         self.set_points()
-        # self.rlv_window.update_settings(*args, **kwds)
 
 
 class RLVWindow:

--- a/dgw/rlv/viewer.py
+++ b/dgw/rlv/viewer.py
@@ -41,7 +41,7 @@ model_view_matrix = None
 
 
 @magicgui(auto_call=True, d_min={"label": "high resolution", "step": 0.05})
-def rlv_settings(
+def rlv_display(
     viewer: napari.Viewer, marker_size: int, d_min: float, z_min: int, z_max: int
 ):
     for layer in viewer.layers:
@@ -154,17 +154,17 @@ class ReciprocalLatticeViewer(Render3d):
         # Set rotation around the origin
         napari_viewer.camera.center = (0, 0, 0)
 
-        # Add the rlv_settings widget and set values and limits
-        napari_viewer.window.add_dock_widget(rlv_settings, name="rlv settings")
-        rlv_settings.marker_size.value = self.settings.marker_size
-        rlv_settings.d_min.value = self.settings.d_min
-        rlv_settings.d_min.min = self.settings.d_min
-        rlv_settings.z_min.value = self.settings.z_min
-        rlv_settings.z_min.min = self.settings.z_min
-        rlv_settings.z_min.max = self.settings.z_max
-        rlv_settings.z_max.value = self.settings.z_max
-        rlv_settings.z_max.min = self.settings.z_min
-        rlv_settings.z_max.max = self.settings.z_max
+        # Add the rlv_display widget and set values and limits
+        napari_viewer.window.add_dock_widget(rlv_display, name="rlv display")
+        rlv_display.marker_size.value = self.settings.marker_size
+        rlv_display.d_min.value = self.settings.d_min
+        rlv_display.d_min.min = self.settings.d_min
+        rlv_display.z_min.value = self.settings.z_min
+        rlv_display.z_min.min = self.settings.z_min
+        rlv_display.z_min.max = self.settings.z_max
+        rlv_display.z_max.value = self.settings.z_max
+        rlv_display.z_max.min = self.settings.z_min
+        rlv_display.z_max.max = self.settings.z_max
 
         return
 

--- a/dgw/rlv/viewer.py
+++ b/dgw/rlv/viewer.py
@@ -65,13 +65,14 @@ class ReciprocalLatticeViewer(Render3d):
         self.napari_viewer = napari_viewer
 
     @magicgui(auto_call=True)
-    def rlv_geometry(self, invert_rotation_axis: bool):
+    def rlv_geometry(self, invert_rotation_axis: bool, crystal_frame: bool):
 
         # Clear current layers
         self.napari_viewer.layers.clear()
 
         # Set values
         self.settings.reverse_phi = invert_rotation_axis
+        self.settings.crystal_frame = crystal_frame
 
         self.add_layers()
 

--- a/dgw/rlv/viewer.py
+++ b/dgw/rlv/viewer.py
@@ -144,14 +144,26 @@ class ReciprocalLatticeViewer(Render3d):
         shapes = [line]
         edge_colors = [(1, 1, 1)]
 
+        axis_layer = napari_viewer.add_shapes(
+            shapes,
+            shape_type="line",
+            edge_width=0.1,
+            edge_color=edge_colors,
+            name="axis",
+        )
+
         # Add reciprocal cells
         cells, cell_colors = self.viewer.draw_cells()
-        shapes.extend(cells)
-        edge_colors.extend(cell_colors)
+        # shapes.extend(cells)
+        # edge_colors.extend(cell_colors)
 
         edge_colors = np.array(edge_colors)
-        shapes_layer = napari_viewer.add_shapes(
-            shapes, shape_type="line", edge_width=0.1, edge_color=edge_colors
+        cells_layer = napari_viewer.add_shapes(
+            cells,
+            shape_type="line",
+            edge_width=0.1,
+            edge_color=cell_colors,
+            name="cells",
         )
 
         return

--- a/dgw/rlv/viewer.py
+++ b/dgw/rlv/viewer.py
@@ -5,18 +5,10 @@ import numpy as np
 
 import libtbx.phil
 
-# import wxtbx.utils
 from libtbx import Auto
 from scitbx.array_family import flex
 from scitbx.math import minimum_covering_sphere
 
-# from wxtbx.segmentedctrl import (
-#    SEGBTN_HORIZONTAL,
-#    SegmentedRadioControl,
-#    SegmentedToggleControl,
-# )
-
-# from dials.util import wx_viewer
 from dials_scratch.dgw.rlv import Render3d
 from dxtbx import flumpy
 
@@ -43,45 +35,13 @@ model_view_matrix = None
 )
 
 
-## WX3 - WX4 compatibility
-# def _rewrite_event(unbound):
-#    """Decorator to intercept the event and add missing instance methods"""
-#
-#    def _wrapp(self, event):
-#        event.GetPositionTuple = event.GetPosition
-#        return unbound(self, event)
-#
-#    return _wrapp
-
-
-## HACK: Monkeypatch wxtbx so that we don't use old interfaces
-# wxtbx.segmentedctrl.SegmentedControl.HitTest = _rewrite_event(
-#    wxtbx.segmentedctrl.SegmentedControl.HitTest
-# )
-# wxtbx.segmentedctrl.SegmentedControl.OnMotion = _rewrite_event(
-#    wxtbx.segmentedctrl.SegmentedControl.OnMotion
-# )
-
-
 class ReciprocalLatticeViewer(Render3d):
     def __init__(self, parent, id, title, size, settings=None, *args, **kwds):
-        # wx.Frame.__init__(self, parent, id, title, size=size, *args, **kwds)
         Render3d.__init__(self, settings=settings)
-        # self.parent = self.GetParent()
-        # self.statusbar = self.CreateStatusBar()
-        # self.sizer = wx.BoxSizer(wx.HORIZONTAL)
 
-        # self.create_settings_panel()
-        # self.sizer.Add(self.settings_panel, 0, wx.EXPAND)
-        self.create_viewer_panel()
-        # self.sizer.Add(self.viewer, 1, wx.EXPAND | wx.ALL)
-        # self.SetSizerAndFit(self.sizer)
-        # self.SetMinSize(self.settings_panel.GetSize())
-        # self.Bind(wx.EVT_CLOSE, self.OnClose, self)
-        # self.Bind(wx.EVT_WINDOW_DESTROY, self.OnDestroy, self)
-        # self.Bind(wx.EVT_ACTIVATE, self.OnActive)
-        # self.viewer.Bind(wx.EVT_KEY_DOWN, self.OnKeyDown)
-        # self.viewer.SetFocus()
+        self.viewer = RLVWindow(
+            settings=self.settings,
+        )
 
     def add_to_napari(self, napari_viewer):
         """Add the layers data to a napari viewer"""
@@ -183,18 +143,6 @@ class ReciprocalLatticeViewer(Render3d):
             marker_size = max(marker_size, 0.5)
             marker_size = min(marker_size, 5)
             self.settings.marker_size = marker_size
-
-    def create_viewer_panel(self):
-        if self.settings.black_background:
-            background_rgb = (0, 0, 0)
-        else:
-            background_rgb = (255, 255, 255)
-        self.viewer = RLVWindow(
-            settings=self.settings,
-            parent=self,
-            size=(800, 600),
-            background_rgb=background_rgb,
-        )
 
     def set_points(self):
         Render3d.set_points(self)

--- a/dgw/rlv/viewer.py
+++ b/dgw/rlv/viewer.py
@@ -142,14 +142,14 @@ class ReciprocalLatticeViewer(Render3d):
         # Struggling to add these shapes individually to separate layers. Let's
         # just accumulate all shapes and then add them all at once
         shapes = [line]
-        edge_colors = [(255, 255, 255)]
-        shape_type = ["line"]
+        edge_colors = [(1, 1, 1)]
 
         # Add reciprocal cells
         cells, cell_colors = self.viewer.draw_cells()
         shapes.extend(cells)
         edge_colors.extend(cell_colors)
 
+        edge_colors = np.array(edge_colors)
         shapes_layer = napari_viewer.add_shapes(
             shapes, shape_type="line", edge_width=0.1, edge_color=edge_colors
         )
@@ -269,7 +269,6 @@ class RLVWindow:
                     j = (i + 1) % self.palette.size()
                     colors.extend([self.palette[j]] * 12)
                     lines.extend(self.cell_edges(axes))
-        colors = np.array(colors)
         return lines, colors
 
     def cell_edges(self, axes):

--- a/dgw/rlv/viewer.py
+++ b/dgw/rlv/viewer.py
@@ -109,6 +109,7 @@ class ReciprocalLatticeViewer(Render3d):
                 size=self.settings.marker_size,
                 name=f"relps id: {exp_id}",
             )
+            relps_layer.blending = "translucent_no_depth"
 
             # Add the cell as a shapes layer, if it exists
             cell = cells.get(exp_id)

--- a/dgw/rlv/viewer.py
+++ b/dgw/rlv/viewer.py
@@ -267,8 +267,7 @@ class ReciprocalLatticeViewer(Render3d):
                 if layer_name in self._rlv_layers:
                     # Update existing layer
                     cell_layer = self._rlv_layers[layer_name]
-                    # Currently update is disabled due to a bug: https://github.com/napari/napari/issues/4527
-                    # cell_layer.data = cell.lines
+                    cell_layer.data = cell.lines
                     cell_layer.refresh()
                 else:
                     # Create new layer

--- a/dgw/rlv/viewer.py
+++ b/dgw/rlv/viewer.py
@@ -14,6 +14,9 @@ from dxtbx import flumpy
 from collections import namedtuple
 from napari.experimental import link_layers
 
+from magicgui import magicgui
+import napari
+
 phil_scope = libtbx.phil.parse(
     """
 include scope dials.util.reciprocal_lattice.phil_scope
@@ -35,6 +38,14 @@ model_view_matrix = None
 """,
     process_includes=True,
 )
+
+
+@magicgui
+def rlv_settings(viewer: napari.Viewer, marker_size: float):
+    for layer in viewer.layers:
+        if layer.name.startswith("relps"):
+            layer.size[:] = marker_size
+            layer.refresh()
 
 
 class ReciprocalLatticeViewer(Render3d):
@@ -135,6 +146,8 @@ class ReciprocalLatticeViewer(Render3d):
 
         # Set rotation around the origin
         napari_viewer.camera.center = (0, 0, 0)
+
+        napari_viewer.window.add_dock_widget(rlv_settings)
 
         return
 

--- a/dgw/rlv/viewer.py
+++ b/dgw/rlv/viewer.py
@@ -149,7 +149,7 @@ class ReciprocalLatticeViewer(Render3d):
         napari_viewer.camera.center = (0, 0, 0)
 
         # Add the rlv_settings widget and set values
-        napari_viewer.window.add_dock_widget(rlv_settings)
+        napari_viewer.window.add_dock_widget(rlv_settings, name="rlv settings")
         rlv_settings.marker_size.value = self.settings.marker_size
 
         return

--- a/dgw/rlv/viewer.py
+++ b/dgw/rlv/viewer.py
@@ -3,13 +3,6 @@ from __future__ import annotations
 from math import pi
 import numpy as np
 
-# import wx
-from annlib_ext import AnnAdaptorSelfInclude
-
-# from wx.lib.agw import floatspin
-
-# import gltbx
-# import gltbx.gl as gl
 import libtbx.phil
 
 # import wxtbx.utils
@@ -93,8 +86,8 @@ class ReciprocalLatticeViewer(Render3d):
     def add_to_napari(self, napari_viewer):
         """Add the layers data to a napari viewer"""
 
-        # In dials.reciprocal_lattice_viewer, the drawing is handled by an RLVWindow
-        # instance, which here is self.viewer. Start with the points
+        # NB In dials.reciprocal_lattice_viewer, the drawing is handled by an
+        # RLVWindow instance, which here is self.viewer.
 
         # Convert points and colors to numpy arrays
         points = flumpy.to_numpy(self.viewer.points)
@@ -128,6 +121,7 @@ class ReciprocalLatticeViewer(Render3d):
             "label": labels,
         }
 
+        # Add the points layer. Only a single layer for now, with all points
         points_layer = napari_viewer.add_points(
             points,
             properties=point_properties,
@@ -146,7 +140,7 @@ class ReciprocalLatticeViewer(Render3d):
         )
 
         # Struggling to add these shapes individually to separate layers. Let's
-        # just accumulate all shapes and add them all at once
+        # just accumulate all shapes and then add them all at once
         shapes = [line]
         edge_colors = [(255, 255, 255)]
         shape_type = ["line"]
@@ -160,15 +154,12 @@ class ReciprocalLatticeViewer(Render3d):
             shapes, shape_type="line", edge_width=0.1, edge_color=edge_colors
         )
 
-        # self.viewer.points
-        # self.viewer.colors
-        # self.viewer.points_data
+        return
 
     def load_models(self, experiments, reflections):
         Render3d.load_models(self, experiments, reflections)
         if self.settings.beam_centre is not None:
-            # self.settings_panel.beam_fast_ctrl.SetValue(self.settings.beam_centre[0])
-            # self.settings_panel.beam_slow_ctrl.SetValue(self.settings.beam_centre[1])
+
             pass
         if self.settings.marker_size is Auto:
             max_radius = max(self.reflections["rlp"].norms())
@@ -180,47 +171,6 @@ class ReciprocalLatticeViewer(Render3d):
             marker_size = max(marker_size, 0.5)
             marker_size = min(marker_size, 5)
             self.settings.marker_size = marker_size
-        # self.settings_panel.marker_size_ctrl.SetValue(self.settings.marker_size)
-        # self.settings_panel.add_experiments_buttons()
-
-    # def OnActive(self, event):
-    #    if self.IsShown() and type(self.viewer).__name__ != "_wxPyDeadObject":
-    #        self.viewer.Refresh()
-
-    # def OnClose(self, event):
-    #    self.Unbind(wx.EVT_ACTIVATE)
-    #    self.Destroy()
-    #    event.Skip()
-
-    # def OnDestroy(self, event):
-    #    if self.parent is not None:
-    #        self.parent.viewer = None
-    #    event.Skip()
-
-    # def OnKeyDown(self, event):
-    #    key = event.GetUnicodeKey()
-    #    if key == wx.WXK_NONE:
-    #        key = event.GetKeyCode()
-    #    dxs = {wx.WXK_LEFT: -1, wx.WXK_RIGHT: +1, wx.WXK_UP: 0, wx.WXK_DOWN: 0}
-    #    dys = {wx.WXK_LEFT: 0, wx.WXK_RIGHT: 0, wx.WXK_UP: +1, wx.WXK_DOWN: -1}
-    #
-    #    if key in dxs:
-    #        dx = dxs[key]
-    #        dy = dys[key]
-    #        if event.ShiftDown():
-    #            scale = 0.1
-    #        else:
-    #            scale = 1.0
-    #        self.do_Step(dx, dy, scale)
-
-    # def do_Step(self, dx, dy, scale):
-    #    v = self.viewer
-    #    rc = v.rotation_center
-    #    gl.glMatrixMode(gl.GL_MODELVIEW)
-    #    gltbx.util.rotate_object_about_eye_x_and_y(
-    #        scale, rc[0], rc[1], rc[2], dx, dy, 0, 0
-    #    )
-    #    v.OnRedraw()
 
     def create_viewer_panel(self):
         if self.settings.black_background:
@@ -234,24 +184,8 @@ class ReciprocalLatticeViewer(Render3d):
             background_rgb=background_rgb,
         )
 
-    # def create_settings_panel(self):
-    #    self.settings_panel = SettingsWindow(self, -1, style=wx.RAISED_BORDER)
-
     def set_points(self):
         Render3d.set_points(self)
-        # self.settings_panel.d_min_ctrl.SetValue(self.settings.d_min)
-        # self.settings_panel.z_min_ctrl.SetValue(self.settings.z_min)
-        # self.settings_panel.z_max_ctrl.SetValue(self.settings.z_max)
-        # self.settings_panel.n_min_ctrl.SetValue(self.settings.n_min)
-        # self.settings_panel.n_max_ctrl.SetValue(self.settings.n_max)
-        # if self.settings.partiality_min is not None:
-        #    self.settings_panel.partiality_min_ctrl.SetValue(
-        #        self.settings.partiality_min
-        #    )
-        # if self.settings.partiality_max is not None:
-        #    self.settings_panel.partiality_max_ctrl.SetValue(
-        #        self.settings.partiality_max
-        #    )
 
     def update_settings(self, *args, **kwds):
         self.set_beam_centre(self.settings.beam_centre_panel, self.settings.beam_centre)
@@ -259,312 +193,9 @@ class ReciprocalLatticeViewer(Render3d):
         self.set_points()
         self.viewer.update_settings(*args, **kwds)
 
-    # def update_statusbar(self):
-    #    model_view_matrix = gltbx.util.get_gl_modelview_matrix()
-    #    txt = (
-    #        "Model view matrix: "
-    #        + "["
-    #        + ", ".join("%.4f" % m for m in model_view_matrix)
-    #        + "]"
-    #    )
-    #    self.statusbar.SetStatusText(txt)
-
-
-# class SettingsWindow(wxtbx.utils.SettingsPanel):
-#    def __init__(self, *args, **kwds):
-#        wxtbx.utils.SettingsPanel.__init__(self, *args, **kwds)
-#        self.Bind(wx.EVT_CHAR, self.OnChar)
-#
-#    def OnChar(self, event):
-#        self.GetParent().viewer.OnChar(event)
-#
-#    def add_controls(self):
-#        # d_min control
-#
-#        self.d_min_ctrl = floatspin.FloatSpin(
-#            parent=self, increment=0.05, min_val=0, digits=2
-#        )
-#        self.d_min_ctrl.Bind(wx.EVT_SET_FOCUS, lambda evt: None)
-#        if wx.VERSION >= (2, 9):  # XXX FloatSpin bug in 2.9.2/wxOSX_Cocoa
-#            self.d_min_ctrl.SetBackgroundColour(self.GetBackgroundColour())
-#        box = wx.BoxSizer(wx.HORIZONTAL)
-#        self.panel_sizer.Add(box)
-#        label = wx.StaticText(self, -1, "High resolution:")
-#        box.Add(label, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
-#        box.Add(self.d_min_ctrl, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
-#        self.Bind(floatspin.EVT_FLOATSPIN, self.OnChangeSettings, self.d_min_ctrl)
-#
-#        self.z_min_ctrl = floatspin.FloatSpin(
-#            parent=self, increment=1, min_val=0, digits=0
-#        )
-#        self.z_min_ctrl.Bind(wx.EVT_SET_FOCUS, lambda evt: None)
-#        if wx.VERSION >= (2, 9):  # XXX FloatSpin bug in 2.9.2/wxOSX_Cocoa
-#            self.z_min_ctrl.SetBackgroundColour(self.GetBackgroundColour())
-#        box = wx.BoxSizer(wx.HORIZONTAL)
-#        self.panel_sizer.Add(box)
-#        label = wx.StaticText(self, -1, "Min Z")
-#        box.Add(label, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
-#        box.Add(self.z_min_ctrl, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
-#        self.Bind(floatspin.EVT_FLOATSPIN, self.OnChangeSettings, self.z_min_ctrl)
-#
-#        self.z_max_ctrl = floatspin.FloatSpin(
-#            parent=self, increment=1, min_val=0, digits=0
-#        )
-#        self.z_max_ctrl.Bind(wx.EVT_SET_FOCUS, lambda evt: None)
-#        if wx.VERSION >= (2, 9):  # XXX FloatSpin bug in 2.9.2/wxOSX_Cocoa
-#            self.z_max_ctrl.SetBackgroundColour(self.GetBackgroundColour())
-#        box = wx.BoxSizer(wx.HORIZONTAL)
-#        self.panel_sizer.Add(box)
-#        label = wx.StaticText(self, -1, "Max Z")
-#        box.Add(label, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
-#        box.Add(self.z_max_ctrl, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
-#        self.Bind(floatspin.EVT_FLOATSPIN, self.OnChangeSettings, self.z_max_ctrl)
-#
-#        # Control for spot size (utility depends on n_signal column in reflection
-#        # file - will be ignored if not in file
-#
-#        self.n_min_ctrl = floatspin.FloatSpin(
-#            parent=self, increment=1, min_val=0, digits=0
-#        )
-#        self.n_min_ctrl.Bind(wx.EVT_SET_FOCUS, lambda evt: None)
-#        if wx.VERSION >= (2, 9):  # XXX FloatSpin bug in 2.9.2/wxOSX_Cocoa
-#            self.n_min_ctrl.SetBackgroundColour(self.GetBackgroundColour())
-#        box = wx.BoxSizer(wx.HORIZONTAL)
-#        self.panel_sizer.Add(box)
-#        label = wx.StaticText(self, -1, "Min Pixels")
-#        box.Add(label, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
-#        box.Add(self.n_min_ctrl, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
-#        self.Bind(floatspin.EVT_FLOATSPIN, self.OnChangeSettings, self.n_min_ctrl)
-#
-#        self.n_max_ctrl = floatspin.FloatSpin(
-#            parent=self, increment=1, min_val=0, digits=0
-#        )
-#        self.n_max_ctrl.Bind(wx.EVT_SET_FOCUS, lambda evt: None)
-#        if wx.VERSION >= (2, 9):  # XXX FloatSpin bug in 2.9.2/wxOSX_Cocoa
-#            self.n_max_ctrl.SetBackgroundColour(self.GetBackgroundColour())
-#        box = wx.BoxSizer(wx.HORIZONTAL)
-#        self.panel_sizer.Add(box)
-#        label = wx.StaticText(self, -1, "Max Pixels")
-#        box.Add(label, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
-#        box.Add(self.n_max_ctrl, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
-#        self.Bind(floatspin.EVT_FLOATSPIN, self.OnChangeSettings, self.n_max_ctrl)
-#
-#        # end new control
-#
-#        self.partiality_min_ctrl = floatspin.FloatSpin(
-#            parent=self, increment=0.01, digits=3, min_val=0, max_val=1
-#        )
-#        self.partiality_min_ctrl.Bind(wx.EVT_SET_FOCUS, lambda evt: None)
-#        if wx.VERSION >= (2, 9):  # XXX FloatSpin bug in 2.9.2/wxOSX_Cocoa
-#            self.partiality_min_ctrl.SetBackgroundColour(self.GetBackgroundColour())
-#        box = wx.BoxSizer(wx.HORIZONTAL)
-#        self.panel_sizer.Add(box)
-#        label = wx.StaticText(self, -1, "Min partiality")
-#        box.Add(label, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
-#        box.Add(self.partiality_min_ctrl, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
-#        self.Bind(
-#            floatspin.EVT_FLOATSPIN, self.OnChangeSettings, self.partiality_min_ctrl
-#        )
-#
-#        self.partiality_max_ctrl = floatspin.FloatSpin(
-#            parent=self, increment=0.01, digits=3, min_val=0, max_val=1
-#        )
-#        self.partiality_max_ctrl.Bind(wx.EVT_SET_FOCUS, lambda evt: None)
-#        if wx.VERSION >= (2, 9):  # XXX FloatSpin bug in 2.9.2/wxOSX_Cocoa
-#            self.partiality_max_ctrl.SetBackgroundColour(self.GetBackgroundColour())
-#        box = wx.BoxSizer(wx.HORIZONTAL)
-#        self.panel_sizer.Add(box)
-#        label = wx.StaticText(self, -1, "Max partiality")
-#        box.Add(label, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
-#        box.Add(self.partiality_max_ctrl, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
-#        self.Bind(
-#            floatspin.EVT_FLOATSPIN, self.OnChangeSettings, self.partiality_max_ctrl
-#        )
-#
-#        ctrls = self.create_controls(
-#            setting="show_rotation_axis", label="Show rotation axis"
-#        )
-#        self.panel_sizer.Add(ctrls[0], 0, wx.ALL, 5)
-#        ctrls = self.create_controls(
-#            setting="show_beam_vector", label="Show beam vector"
-#        )
-#        self.panel_sizer.Add(ctrls[0], 0, wx.ALL, 5)
-#        ctrls = self.create_controls(
-#            setting="show_reciprocal_cell", label="Show reciprocal cell"
-#        )
-#        self.panel_sizer.Add(ctrls[0], 0, wx.ALL, 5)
-#        ctrls = self.create_controls(
-#            setting="label_nearest_point", label="Label nearest point"
-#        )
-#        self.panel_sizer.Add(ctrls[0], 0, wx.ALL, 5)
-#        self.reverse_phi_ctrl = self.create_controls(
-#            setting="reverse_phi", label="Invert rotation axis"
-#        )[0]
-#        self.panel_sizer.Add(self.reverse_phi_ctrl, 0, wx.ALL, 5)
-#
-#        self.Bind(wx.EVT_CHECKBOX, self.OnChangeSettings, self.reverse_phi_ctrl)
-#
-#        self.crystal_frame_tooltip = wx.ToolTip(
-#            "Show the reciprocal lattice(s) in the crystal rather than the laboratory frame"
-#        )
-#        self.crystal_frame_ctrl = self.create_controls(
-#            setting="crystal_frame", label="Show in crystal frame"
-#        )[0]
-#        self.crystal_frame_ctrl.SetToolTip(self.crystal_frame_tooltip)
-#        self.panel_sizer.Add(self.crystal_frame_ctrl, 0, wx.ALL, 5)
-#
-#        self.Bind(wx.EVT_CHECKBOX, self.OnChangeSettings, self.crystal_frame_ctrl)
-#
-#        self.beam_panel_ctrl = floatspin.FloatSpin(
-#            parent=self, min_val=0, increment=1, digits=0
-#        )
-#        self.beam_panel_ctrl.Bind(wx.EVT_SET_FOCUS, lambda evt: None)
-#        if wx.VERSION >= (2, 9):  # XXX FloatSpin bug in 2.9.2/wxOSX_Cocoa
-#            self.beam_panel_ctrl.SetBackgroundColour(self.GetBackgroundColour())
-#        box = wx.BoxSizer(wx.HORIZONTAL)
-#        self.panel_sizer.Add(box)
-#        label = wx.StaticText(self, -1, "Beam centre panel")
-#        box.Add(label, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
-#        box.Add(self.beam_panel_ctrl, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
-#        self.Bind(floatspin.EVT_FLOATSPIN, self.OnChangeSettings, self.beam_panel_ctrl)
-#
-#        self.beam_fast_ctrl = floatspin.FloatSpin(parent=self, increment=0.01, digits=2)
-#        self.beam_fast_ctrl.Bind(wx.EVT_SET_FOCUS, lambda evt: None)
-#        if wx.VERSION >= (2, 9):  # XXX FloatSpin bug in 2.9.2/wxOSX_Cocoa
-#            self.beam_fast_ctrl.SetBackgroundColour(self.GetBackgroundColour())
-#        box = wx.BoxSizer(wx.HORIZONTAL)
-#        self.panel_sizer.Add(box)
-#        label = wx.StaticText(self, -1, "Beam centre (mm)")
-#        box.Add(label, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
-#        box.Add(self.beam_fast_ctrl, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
-#        self.Bind(floatspin.EVT_FLOATSPIN, self.OnChangeSettings, self.beam_fast_ctrl)
-#
-#        self.beam_slow_ctrl = floatspin.FloatSpin(parent=self, increment=0.01, digits=2)
-#        self.beam_slow_ctrl.Bind(wx.EVT_SET_FOCUS, lambda evt: None)
-#        if wx.VERSION >= (2, 9):  # XXX FloatSpin bug in 2.9.2/wxOSX_Cocoa
-#            self.beam_slow_ctrl.SetBackgroundColour(self.GetBackgroundColour())
-#        box.Add(self.beam_slow_ctrl, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
-#        self.Bind(floatspin.EVT_FLOATSPIN, self.OnChangeSettings, self.beam_slow_ctrl)
-#
-#        self.marker_size_ctrl = floatspin.FloatSpin(
-#            parent=self, increment=1, digits=0, min_val=1
-#        )
-#        self.marker_size_ctrl.Bind(wx.EVT_SET_FOCUS, lambda evt: None)
-#        if wx.VERSION >= (2, 9):  # XXX FloatSpin bug in 2.9.2/wxOSX_Cocoa
-#            self.marker_size_ctrl.SetBackgroundColour(self.GetBackgroundColour())
-#        box = wx.BoxSizer(wx.HORIZONTAL)
-#        self.panel_sizer.Add(box)
-#        label = wx.StaticText(self, -1, "Marker size:")
-#        box.Add(label, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
-#        box.Add(self.marker_size_ctrl, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
-#        self.Bind(floatspin.EVT_FLOATSPIN, self.OnChangeSettings, self.marker_size_ctrl)
-#
-#        self.btn = SegmentedRadioControl(self, style=SEGBTN_HORIZONTAL)
-#        self.btn.AddSegment("all")
-#        self.btn.AddSegment("indexed")
-#        self.btn.AddSegment("unindexed")
-#        self.btn.AddSegment("integrated")
-#        self.btn.SetSelection(
-#            ["all", "indexed", "unindexed", "integrated"].index(self.settings.display)
-#        )
-#        self.Bind(wx.EVT_RADIOBUTTON, self.OnChangeSettings, self.btn)
-#        self.GetSizer().Add(self.btn, 0, wx.ALL, 5)
-#
-#        self.outlier_btn = SegmentedRadioControl(self, style=SEGBTN_HORIZONTAL)
-#        self.outlier_btn.AddSegment("all")
-#        self.outlier_btn.AddSegment("inliers")
-#        self.outlier_btn.AddSegment("outliers")
-#        self.outlier_btn.SetSelection(
-#            [None, "inliers", "outliers"].index(self.settings.outlier_display)
-#        )
-#        self.Bind(wx.EVT_RADIOBUTTON, self.OnChangeSettings, self.outlier_btn)
-#        self.GetSizer().Add(self.outlier_btn, 0, wx.ALL, 5)
-#
-#    def add_value_widgets(self, sizer):
-#        sizer.Add(
-#            wx.StaticText(self.panel, -1, "Value:"),
-#            0,
-#            wx.ALL | wx.ALIGN_CENTER_VERTICAL,
-#            5,
-#        )
-#        self.value_info = wx.TextCtrl(
-#            self.panel, -1, size=(80, -1), style=wx.TE_READONLY
-#        )
-#        sizer.Add(self.value_info, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
-
-# def add_experiments_buttons(self):
-#    n = flex.max(self.parent.reflections_input["id"])
-#    if n <= 0:
-#        self.expt_btn = None
-#        return
-#
-#    box = wx.BoxSizer(wx.VERTICAL)
-#    self.panel_sizer.Add(box)
-#    label = wx.StaticText(self, -1, "Experiment ids:")
-#    box.Add(label, 0, wx.ALL, 5)
-#
-#    self.expt_btn = SegmentedToggleControl(self, style=SEGBTN_HORIZONTAL)
-#    for i in range(-1, n + 1):
-#        self.expt_btn.AddSegment(str(i))
-#        if (
-#            self.settings.experiment_ids is not None
-#            and i in self.settings.experiment_ids
-#        ):
-#            self.expt_btn.SetValue(i + 1, True)
-#
-#    self.expt_btn.Realize()
-#    self.Bind(wx.EVT_TOGGLEBUTTON, self.OnChangeSettings, self.expt_btn)
-#    box.Add(self.expt_btn, 0, wx.ALL, 5)
-
-#    def OnChangeSettings(self, event):
-#        self.settings.d_min = self.d_min_ctrl.GetValue()
-#        self.settings.z_min = self.z_min_ctrl.GetValue()
-#        self.settings.z_max = self.z_max_ctrl.GetValue()
-#        self.settings.n_min = int(self.n_min_ctrl.GetValue())
-#        self.settings.n_max = int(self.n_max_ctrl.GetValue())
-#        self.settings.partiality_min = self.partiality_min_ctrl.GetValue()
-#        self.settings.partiality_max = self.partiality_max_ctrl.GetValue()
-#
-#        old_beam_panel = self.settings.beam_centre_panel
-#        old_beam_centre = self.settings.beam_centre
-#        self.settings.beam_centre_panel = self.beam_panel_ctrl.GetValue()
-#        self.settings.beam_centre = (
-#            self.beam_fast_ctrl.GetValue(),
-#            self.beam_slow_ctrl.GetValue(),
-#        )
-#        self.settings.reverse_phi = self.reverse_phi_ctrl.GetValue()
-#        self.settings.crystal_frame = self.crystal_frame_ctrl.GetValue()
-#        self.settings.marker_size = self.marker_size_ctrl.GetValue()
-#        for i, display in enumerate(("all", "indexed", "unindexed", "integrated")):
-#            if self.btn.values[i]:
-#                self.settings.display = display
-#                break
-#
-#        for i, display in enumerate(("all", "inliers", "outliers")):
-#            if self.outlier_btn.values[i]:
-#                self.settings.outlier_display = display
-#                break
-#
-#        if self.expt_btn is not None:
-#            expt_ids = []
-#            for i in range(len(self.expt_btn.segments)):
-#                if self.expt_btn.GetValue(i):
-#                    expt_ids.append(i - 1)
-#            self.settings.experiment_ids = expt_ids
-#
-#        try:
-#            self.parent.update_settings()
-#        except ValueError:  # Handle beam centre changes, which could fail
-#            self.settings.beam_centre_panel = old_beam_panel
-#            self.settings.beam_centre = old_beam_centre
-#            self.beam_panel_ctrl.SetValue(old_beam_panel)
-#            self.beam_fast_ctrl.SetValue(old_beam_centre[0])
-#            self.beam_slow_ctrl.SetValue(old_beam_centre[1])
-
 
 class RLVWindow:
     def __init__(self, settings, *args, **kwds):
-        # super().__init__(*args, **kwds)
         self.settings = settings
         self.points = flex.vec3_double()
         self.colors = None
@@ -576,11 +207,6 @@ class RLVWindow:
         self.flag_show_minimum_covering_sphere = False
         self.minimum_covering_sphere = None
         self.field_of_view_y = 0.001
-        # if self.settings.autospin:
-        #    self.autospin_allowed = True
-        #    self.yspin = 1
-        #    self.xspin = 1
-        #    self.autospin = True
 
     def set_points(self, points):
         self.points = points
@@ -607,18 +233,6 @@ class RLVWindow:
     def set_palette(self, palette):
         self.palette = palette
 
-    def draw_points(self):
-        if self.points_display_list is None:
-            self.points_display_list = gltbx.gl_managed.display_list()
-            self.points_display_list.compile()
-            gl.glLineWidth(1)
-            if self.colors is None:
-                self.colors = flex.vec3_double(len(self.points), (1, 1, 1))
-            for point, color in zip(self.points, self.colors):
-                self.draw_cross_at(point, color=color)
-            self.points_display_list.end()
-        self.points_display_list.call()
-
     def set_rotation_axis(self, axis):
         self.rotation_axis = axis
 
@@ -631,30 +245,10 @@ class RLVWindow:
     def set_reciprocal_crystal_vectors(self, vectors_per_crystal):
         self.recip_crystal_vectors = vectors_per_crystal
 
-    # --- user input and settings
-    # def update_settings(self):
-    #    self.points_display_list = None
-    #    self.Refresh()
-
     def update_minimum_covering_sphere(self):
         n_points = min(1000, self.points.size())
         isel = flex.random_permutation(self.points.size())[:n_points]
         self.minimum_covering_sphere = minimum_covering_sphere(self.points.select(isel))
-
-    def draw_cross_at(self, xyz, color=(1, 1, 1), f=None):
-        (x, y, z) = xyz
-        if f is None:
-            f = 0.01 * self.settings.marker_size
-        wx_viewer.show_points_and_lines_mixin.draw_cross_at(
-            self, (x, y, z), color=color, f=f
-        )
-
-    # def DrawGL(self):
-    #    wx_viewer.show_points_and_lines_mixin.DrawGL(self)
-    #    if self.rotation_axis is not None and self.settings.show_rotation_axis:
-    #        self.draw_axis(self.rotation_axis, "phi")
-    #    if self.beam_vector is not None and self.settings.show_beam_vector:
-    #        self.draw_axis(self.beam_vector, "beam")
 
     def draw_cells(self):
         """Create a list of lines corresponding to reciprocal unit cells"""
@@ -678,39 +272,6 @@ class RLVWindow:
         colors = np.array(colors)
         return lines, colors
 
-        # if self.settings.label_nearest_point:
-        #    self.label_nearest_point()
-
-        # self.GetParent().update_statusbar()
-
-    # def draw_axis(self, axis, label):
-    #    if self.minimum_covering_sphere is None:
-    #        self.update_minimum_covering_sphere()
-    #    s = self.minimum_covering_sphere
-    #    scale = max(max(s.box_max()), abs(min(s.box_min())))
-    #    #gltbx.fonts.ucs_bitmap_8x13.setup_call_lists()
-    #    #gl.glDisable(gl.GL_LIGHTING)
-    #    #if self.settings.black_background:
-    #    #    gl.glColor3f(1.0, 1.0, 1.0)
-    #    #else:
-    #    #    gl.glColor3f(0.0, 0.0, 0.0)
-    #    #gl.glLineWidth(1.0)
-    #    #gl.glBegin(gl.GL_LINES)
-    #    gl.glVertex3f(0.0, 0.0, 0.0)
-    #    gl.glVertex3f(axis[0] * scale, axis[1] * scale, axis[2] * scale)
-    #    gl.glEnd()
-    #    gl.glRasterPos3f(
-    #        0.5 + axis[0] * scale, 0.2 + axis[1] * scale, 0.2 + axis[2] * scale
-    #    )
-    #    gltbx.fonts.ucs_bitmap_8x13.render_string(label)
-    #    gl.glEnable(gl.GL_LINE_STIPPLE)
-    #    gl.glLineStipple(4, 0xAAAA)
-    #    gl.glBegin(gl.GL_LINES)
-    #    gl.glVertex3f(0.0, 0.0, 0.0)
-    #    gl.glVertex3f(-axis[0] * scale, -axis[1] * scale, -axis[2] * scale)
-    #    gl.glEnd()
-    #    gl.glDisable(gl.GL_LINE_STIPPLE)
-
     def cell_edges(self, axes):
         astar, bstar, cstar = axes[0], axes[1], axes[2]
         farpoint = astar + bstar + cstar
@@ -730,43 +291,3 @@ class RLVWindow:
             np.array([[*farpoint.elems], [*(farpoint - cstar).elems]]),
         ]
         return lines
-
-    def label_nearest_point(self):
-        ann = AnnAdaptorSelfInclude(self.points.as_double(), 3)
-        ann.query(self.rotation_center)
-        i = ann.nn[0]
-        gltbx.fonts.ucs_bitmap_8x13.setup_call_lists()
-        gl.glDisable(gl.GL_LIGHTING)
-        gl.glColor3f(1.0, 1.0, 1.0)
-        gl.glLineWidth(1.0)
-        xyz = self.points_data["xyz"][i]
-        exp_id = self.points_data["id"][i]
-        panel = self.points_data["panel"][i]
-        d_spacing = self.points_data["d_spacing"][i]
-        label = (
-            f"id: {exp_id}; panel: {panel}\n"
-            f"xyz: {xyz[0]:.1f} {xyz[1]:.1f} {xyz[2]:.1f}\n"
-            f"res: {d_spacing:.2f} Angstrom"
-        )
-        if "miller_index" in self.points_data and exp_id != -1:
-            hkl = self.points_data["miller_index"][i]
-            label += f"\nhkl: {hkl}"
-        line_spacing = round(gltbx.fonts.ucs_bitmap_8x13.height())
-        for j, string in enumerate(label.splitlines()):
-            gl.glRasterPos3f(*self.points[i])
-            gl.glBitmap(0, 0, 0.0, 0.0, line_spacing, -j * line_spacing, b" ")
-            gltbx.fonts.ucs_bitmap_8x13.render_string(string)
-
-    # def rotate_view(self, x1, y1, x2, y2, shift_down=False, scale=0.1):
-    #    super().rotate_view(x1, y1, x2, y2, shift_down=shift_down, scale=scale)
-
-    # def OnLeftUp(self, event):
-    #    self.was_dragged = True
-    #    super().OnLeftUp(event)
-
-    # def initialize_modelview(self, eye_vector=None, angle=None):
-    #    super().initialize_modelview(eye_vector=eye_vector, angle=angle)
-    #    self.rotation_center = (0, 0, 0)
-    #    self.move_to_center_of_viewport(self.rotation_center)
-    #    if self.settings.model_view_matrix is not None:
-    #        gl.glLoadMatrixd(self.settings.model_view_matrix)

--- a/dgw/rlv/viewer.py
+++ b/dgw/rlv/viewer.py
@@ -207,7 +207,7 @@ class ReciprocalLatticeViewer(Render3d):
                 size=self.settings.marker_size,
                 name=f"relps id: {exp_id}",
             )
-            relps_layer.blending = "translucent_no_depth"
+            relps_layer.blending = "opaque"
 
             @relps_layer.mouse_drag_callbacks.append
             def show_point_info(layer, event):

--- a/dgw/rlv/viewer.py
+++ b/dgw/rlv/viewer.py
@@ -127,7 +127,6 @@ class ReciprocalLatticeViewer(Render3d):
             rlv_display.outlier_status.value = OutlierStatus.inliers
         if self.settings.outlier_display == "outliers":
             rlv_display.outlier_status.value = OutlierStatus.outliers
-        rlv_display.max_height = 400  # not ideal workaround https://forum.image.sc/t/magicgui-widget-spacing/66954/3?u=dagewa
 
         # Add the rlv_geometry widget and set values
         self.napari_viewer.window.add_dock_widget(
@@ -135,6 +134,10 @@ class ReciprocalLatticeViewer(Render3d):
         )
         self.rlv_geometry.invert_rotation_axis.value = self.settings.reverse_phi
         self.rlv_geometry.crystal_frame.value = self.settings.crystal_frame
+
+        # not ideal workaround https://forum.image.sc/t/magicgui-widget-spacing/66954/3?u=dagewa
+        rlv_display.max_height = 200
+        self.rlv_geometry.max_height = 200
 
         # Add the relp status display
         self.relp_status = Label(value="")

--- a/dgw/rlv/viewer.py
+++ b/dgw/rlv/viewer.py
@@ -151,9 +151,6 @@ class ReciprocalLatticeViewer(Render3d):
             name="axis",
         )
 
-        # Set rotation around the origin
-        napari_viewer.camera.center = (0, 0, 0)
-
         # Add the rlv_display widget and set values and limits
         napari_viewer.window.add_dock_widget(rlv_display, name="rlv display")
         rlv_display.marker_size.value = self.settings.marker_size

--- a/dgw/rlv/viewer.py
+++ b/dgw/rlv/viewer.py
@@ -47,6 +47,13 @@ class OutlierStatus(Enum):
     outliers = 2
 
 
+class ReflectionStatus(Enum):
+    all = 0
+    unindexed = 1
+    indexed = 2
+    integrated = 3
+
+
 @magicgui(auto_call=True, d_min={"label": "high resolution", "step": 0.05})
 def rlv_display(
     viewer: napari.Viewer,
@@ -55,6 +62,7 @@ def rlv_display(
     z_min: int,
     z_max: int,
     outlier_status=OutlierStatus.all,
+    reflection_status=ReflectionStatus.all,
 ):
     for layer in viewer.layers:
         if layer.name.startswith("relps"):
@@ -66,6 +74,12 @@ def rlv_display(
                 shown = shown & ~layer.properties["outlier_status"]
             elif outlier_status is OutlierStatus.outliers:
                 shown = shown & layer.properties["outlier_status"]
+            if reflection_status is ReflectionStatus.unindexed:
+                shown = shown & layer.properties["unindexed_status"]
+            if reflection_status is ReflectionStatus.indexed:
+                shown = shown & layer.properties["indexed_status"]
+            if reflection_status is ReflectionStatus.integrated:
+                shown = shown & layer.properties["integrated_status"]
             layer.shown = shown
             layer.refresh()
 

--- a/dgw/rlv/viewer.py
+++ b/dgw/rlv/viewer.py
@@ -126,6 +126,7 @@ class ReciprocalLatticeViewer(Render3d):
             rlv_display.outlier_status.value = OutlierStatus.inliers
         if self.settings.outlier_display == "outliers":
             rlv_display.outlier_status.value = OutlierStatus.outliers
+        rlv_display.max_height = 400  # not ideal workaround https://forum.image.sc/t/magicgui-widget-spacing/66954/3?u=dagewa
 
         # Add the rlv_geometry widget and set values
         self.napari_viewer.window.add_dock_widget(

--- a/dgw/rlv/viewer.py
+++ b/dgw/rlv/viewer.py
@@ -1,0 +1,772 @@
+from __future__ import annotations
+
+from math import pi
+import numpy as np
+
+# import wx
+from annlib_ext import AnnAdaptorSelfInclude
+
+# from wx.lib.agw import floatspin
+
+# import gltbx
+# import gltbx.gl as gl
+import libtbx.phil
+
+# import wxtbx.utils
+from libtbx import Auto
+from scitbx.array_family import flex
+from scitbx.math import minimum_covering_sphere
+
+# from wxtbx.segmentedctrl import (
+#    SEGBTN_HORIZONTAL,
+#    SegmentedRadioControl,
+#    SegmentedToggleControl,
+# )
+
+# from dials.util import wx_viewer
+from dials_scratch.dgw.rlv import Render3d
+from dxtbx import flumpy
+
+phil_scope = libtbx.phil.parse(
+    """
+include scope dials.util.reciprocal_lattice.phil_scope
+
+show_rotation_axis = False
+  .type = bool
+show_beam_vector = False
+  .type = bool
+show_reciprocal_cell = True
+  .type = bool
+label_nearest_point = False
+  .type = bool
+marker_size = Auto
+  .type = int(value_min=1)
+autospin = False
+  .type = bool
+model_view_matrix = None
+  .type = floats(size=16)
+""",
+    process_includes=True,
+)
+
+
+## WX3 - WX4 compatibility
+# def _rewrite_event(unbound):
+#    """Decorator to intercept the event and add missing instance methods"""
+#
+#    def _wrapp(self, event):
+#        event.GetPositionTuple = event.GetPosition
+#        return unbound(self, event)
+#
+#    return _wrapp
+
+
+## HACK: Monkeypatch wxtbx so that we don't use old interfaces
+# wxtbx.segmentedctrl.SegmentedControl.HitTest = _rewrite_event(
+#    wxtbx.segmentedctrl.SegmentedControl.HitTest
+# )
+# wxtbx.segmentedctrl.SegmentedControl.OnMotion = _rewrite_event(
+#    wxtbx.segmentedctrl.SegmentedControl.OnMotion
+# )
+
+
+class ReciprocalLatticeViewer(Render3d):
+    def __init__(self, parent, id, title, size, settings=None, *args, **kwds):
+        # wx.Frame.__init__(self, parent, id, title, size=size, *args, **kwds)
+        Render3d.__init__(self, settings=settings)
+        # self.parent = self.GetParent()
+        # self.statusbar = self.CreateStatusBar()
+        # self.sizer = wx.BoxSizer(wx.HORIZONTAL)
+
+        # self.create_settings_panel()
+        # self.sizer.Add(self.settings_panel, 0, wx.EXPAND)
+        self.create_viewer_panel()
+        # self.sizer.Add(self.viewer, 1, wx.EXPAND | wx.ALL)
+        # self.SetSizerAndFit(self.sizer)
+        # self.SetMinSize(self.settings_panel.GetSize())
+        # self.Bind(wx.EVT_CLOSE, self.OnClose, self)
+        # self.Bind(wx.EVT_WINDOW_DESTROY, self.OnDestroy, self)
+        # self.Bind(wx.EVT_ACTIVATE, self.OnActive)
+        # self.viewer.Bind(wx.EVT_KEY_DOWN, self.OnKeyDown)
+        # self.viewer.SetFocus()
+
+    def add_to_napari(self, napari_viewer):
+        """Add the layers data to a napari viewer"""
+
+        # In dials.reciprocal_lattice_viewer, the drawing is handled by an RLVWindow
+        # instance, which here is self.viewer. Start with the points
+
+        # Convert points and colors to numpy arrays
+        points = flumpy.to_numpy(self.viewer.points)
+        colors = flumpy.to_numpy(self.viewer.colors)
+
+        # Set point labels (could be slow!)
+        labels = []
+        xyz_data = self.viewer.points_data["xyz"]
+        id_data = self.viewer.points_data["id"]
+        panel_data = self.viewer.points_data["panel"]
+        d_spacing_data = self.viewer.points_data["d_spacing"]
+        for xyz, exp_id, panel, d_spacing in zip(
+            xyz_data, id_data, panel_data, d_spacing_data
+        ):
+
+            label = (
+                f"id: {exp_id}; panel: {panel}\n"
+                f"xyz: {xyz[0]:.1f} {xyz[1]:.1f} {xyz[2]:.1f}\n"
+                f"res: {d_spacing:.2f} Angstrom"
+            )
+            labels.append(label)
+        if "miller_index" in self.viewer.points_data:
+            for i, (exp_id, hkl) in enumerate(
+                zip(id_data, self.viewer.points_data["miller_index"])
+            ):
+                if exp_id != -1:
+                    labels[i] += f"\nhkl: {hkl}"
+
+        # These labels are displayed on mouseover of the points
+        point_properties = {
+            "label": labels,
+        }
+
+        points_layer = napari_viewer.add_points(
+            points,
+            properties=point_properties,
+            face_color=colors,
+            size=self.settings.marker_size,
+        )
+
+        # Now add rotation axis. Code extracted from draw_axis
+        if self.viewer.minimum_covering_sphere is None:
+            self.viewer.update_minimum_covering_sphere()
+        s = self.viewer.minimum_covering_sphere
+        scale = max(max(s.box_max()), abs(min(s.box_min())))
+        axis = self.viewer.rotation_axis
+        line = np.array(
+            [[0, 0, 0], [axis[0] * scale, axis[1] * scale, axis[2] * scale]]
+        )
+
+        # Struggling to add these shapes individually to separate layers. Let's
+        # just accumulate all shapes and add them all at once
+        shapes = [line]
+        edge_colors = [(255, 255, 255)]
+        shape_type = ["line"]
+
+        # Add reciprocal cells
+        cells, cell_colors = self.viewer.draw_cells()
+        shapes.extend(cells)
+        edge_colors.extend(cell_colors)
+
+        shapes_layer = napari_viewer.add_shapes(
+            shapes, shape_type="line", edge_width=0.1, edge_color=edge_colors
+        )
+
+        # self.viewer.points
+        # self.viewer.colors
+        # self.viewer.points_data
+
+    def load_models(self, experiments, reflections):
+        Render3d.load_models(self, experiments, reflections)
+        if self.settings.beam_centre is not None:
+            # self.settings_panel.beam_fast_ctrl.SetValue(self.settings.beam_centre[0])
+            # self.settings_panel.beam_slow_ctrl.SetValue(self.settings.beam_centre[1])
+            pass
+        if self.settings.marker_size is Auto:
+            max_radius = max(self.reflections["rlp"].norms())
+            volume = 4 / 3 * pi * max_radius ** 3
+            density = len(self.reflections) / volume
+            # Set marker size to between 0.05 and 0.5 depending on density, where
+            # 1000 < density < 20000 ==> 5 < marker_size < 0.5
+            marker_size = (-0.45 / 19000) * density + (0.05 + 9 / 19)
+            marker_size = max(marker_size, 0.5)
+            marker_size = min(marker_size, 5)
+            self.settings.marker_size = marker_size
+        # self.settings_panel.marker_size_ctrl.SetValue(self.settings.marker_size)
+        # self.settings_panel.add_experiments_buttons()
+
+    # def OnActive(self, event):
+    #    if self.IsShown() and type(self.viewer).__name__ != "_wxPyDeadObject":
+    #        self.viewer.Refresh()
+
+    # def OnClose(self, event):
+    #    self.Unbind(wx.EVT_ACTIVATE)
+    #    self.Destroy()
+    #    event.Skip()
+
+    # def OnDestroy(self, event):
+    #    if self.parent is not None:
+    #        self.parent.viewer = None
+    #    event.Skip()
+
+    # def OnKeyDown(self, event):
+    #    key = event.GetUnicodeKey()
+    #    if key == wx.WXK_NONE:
+    #        key = event.GetKeyCode()
+    #    dxs = {wx.WXK_LEFT: -1, wx.WXK_RIGHT: +1, wx.WXK_UP: 0, wx.WXK_DOWN: 0}
+    #    dys = {wx.WXK_LEFT: 0, wx.WXK_RIGHT: 0, wx.WXK_UP: +1, wx.WXK_DOWN: -1}
+    #
+    #    if key in dxs:
+    #        dx = dxs[key]
+    #        dy = dys[key]
+    #        if event.ShiftDown():
+    #            scale = 0.1
+    #        else:
+    #            scale = 1.0
+    #        self.do_Step(dx, dy, scale)
+
+    # def do_Step(self, dx, dy, scale):
+    #    v = self.viewer
+    #    rc = v.rotation_center
+    #    gl.glMatrixMode(gl.GL_MODELVIEW)
+    #    gltbx.util.rotate_object_about_eye_x_and_y(
+    #        scale, rc[0], rc[1], rc[2], dx, dy, 0, 0
+    #    )
+    #    v.OnRedraw()
+
+    def create_viewer_panel(self):
+        if self.settings.black_background:
+            background_rgb = (0, 0, 0)
+        else:
+            background_rgb = (255, 255, 255)
+        self.viewer = RLVWindow(
+            settings=self.settings,
+            parent=self,
+            size=(800, 600),
+            background_rgb=background_rgb,
+        )
+
+    # def create_settings_panel(self):
+    #    self.settings_panel = SettingsWindow(self, -1, style=wx.RAISED_BORDER)
+
+    def set_points(self):
+        Render3d.set_points(self)
+        # self.settings_panel.d_min_ctrl.SetValue(self.settings.d_min)
+        # self.settings_panel.z_min_ctrl.SetValue(self.settings.z_min)
+        # self.settings_panel.z_max_ctrl.SetValue(self.settings.z_max)
+        # self.settings_panel.n_min_ctrl.SetValue(self.settings.n_min)
+        # self.settings_panel.n_max_ctrl.SetValue(self.settings.n_max)
+        # if self.settings.partiality_min is not None:
+        #    self.settings_panel.partiality_min_ctrl.SetValue(
+        #        self.settings.partiality_min
+        #    )
+        # if self.settings.partiality_max is not None:
+        #    self.settings_panel.partiality_max_ctrl.SetValue(
+        #        self.settings.partiality_max
+        #    )
+
+    def update_settings(self, *args, **kwds):
+        self.set_beam_centre(self.settings.beam_centre_panel, self.settings.beam_centre)
+        self.map_points_to_reciprocal_space()
+        self.set_points()
+        self.viewer.update_settings(*args, **kwds)
+
+    # def update_statusbar(self):
+    #    model_view_matrix = gltbx.util.get_gl_modelview_matrix()
+    #    txt = (
+    #        "Model view matrix: "
+    #        + "["
+    #        + ", ".join("%.4f" % m for m in model_view_matrix)
+    #        + "]"
+    #    )
+    #    self.statusbar.SetStatusText(txt)
+
+
+# class SettingsWindow(wxtbx.utils.SettingsPanel):
+#    def __init__(self, *args, **kwds):
+#        wxtbx.utils.SettingsPanel.__init__(self, *args, **kwds)
+#        self.Bind(wx.EVT_CHAR, self.OnChar)
+#
+#    def OnChar(self, event):
+#        self.GetParent().viewer.OnChar(event)
+#
+#    def add_controls(self):
+#        # d_min control
+#
+#        self.d_min_ctrl = floatspin.FloatSpin(
+#            parent=self, increment=0.05, min_val=0, digits=2
+#        )
+#        self.d_min_ctrl.Bind(wx.EVT_SET_FOCUS, lambda evt: None)
+#        if wx.VERSION >= (2, 9):  # XXX FloatSpin bug in 2.9.2/wxOSX_Cocoa
+#            self.d_min_ctrl.SetBackgroundColour(self.GetBackgroundColour())
+#        box = wx.BoxSizer(wx.HORIZONTAL)
+#        self.panel_sizer.Add(box)
+#        label = wx.StaticText(self, -1, "High resolution:")
+#        box.Add(label, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+#        box.Add(self.d_min_ctrl, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+#        self.Bind(floatspin.EVT_FLOATSPIN, self.OnChangeSettings, self.d_min_ctrl)
+#
+#        self.z_min_ctrl = floatspin.FloatSpin(
+#            parent=self, increment=1, min_val=0, digits=0
+#        )
+#        self.z_min_ctrl.Bind(wx.EVT_SET_FOCUS, lambda evt: None)
+#        if wx.VERSION >= (2, 9):  # XXX FloatSpin bug in 2.9.2/wxOSX_Cocoa
+#            self.z_min_ctrl.SetBackgroundColour(self.GetBackgroundColour())
+#        box = wx.BoxSizer(wx.HORIZONTAL)
+#        self.panel_sizer.Add(box)
+#        label = wx.StaticText(self, -1, "Min Z")
+#        box.Add(label, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+#        box.Add(self.z_min_ctrl, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+#        self.Bind(floatspin.EVT_FLOATSPIN, self.OnChangeSettings, self.z_min_ctrl)
+#
+#        self.z_max_ctrl = floatspin.FloatSpin(
+#            parent=self, increment=1, min_val=0, digits=0
+#        )
+#        self.z_max_ctrl.Bind(wx.EVT_SET_FOCUS, lambda evt: None)
+#        if wx.VERSION >= (2, 9):  # XXX FloatSpin bug in 2.9.2/wxOSX_Cocoa
+#            self.z_max_ctrl.SetBackgroundColour(self.GetBackgroundColour())
+#        box = wx.BoxSizer(wx.HORIZONTAL)
+#        self.panel_sizer.Add(box)
+#        label = wx.StaticText(self, -1, "Max Z")
+#        box.Add(label, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+#        box.Add(self.z_max_ctrl, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+#        self.Bind(floatspin.EVT_FLOATSPIN, self.OnChangeSettings, self.z_max_ctrl)
+#
+#        # Control for spot size (utility depends on n_signal column in reflection
+#        # file - will be ignored if not in file
+#
+#        self.n_min_ctrl = floatspin.FloatSpin(
+#            parent=self, increment=1, min_val=0, digits=0
+#        )
+#        self.n_min_ctrl.Bind(wx.EVT_SET_FOCUS, lambda evt: None)
+#        if wx.VERSION >= (2, 9):  # XXX FloatSpin bug in 2.9.2/wxOSX_Cocoa
+#            self.n_min_ctrl.SetBackgroundColour(self.GetBackgroundColour())
+#        box = wx.BoxSizer(wx.HORIZONTAL)
+#        self.panel_sizer.Add(box)
+#        label = wx.StaticText(self, -1, "Min Pixels")
+#        box.Add(label, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+#        box.Add(self.n_min_ctrl, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+#        self.Bind(floatspin.EVT_FLOATSPIN, self.OnChangeSettings, self.n_min_ctrl)
+#
+#        self.n_max_ctrl = floatspin.FloatSpin(
+#            parent=self, increment=1, min_val=0, digits=0
+#        )
+#        self.n_max_ctrl.Bind(wx.EVT_SET_FOCUS, lambda evt: None)
+#        if wx.VERSION >= (2, 9):  # XXX FloatSpin bug in 2.9.2/wxOSX_Cocoa
+#            self.n_max_ctrl.SetBackgroundColour(self.GetBackgroundColour())
+#        box = wx.BoxSizer(wx.HORIZONTAL)
+#        self.panel_sizer.Add(box)
+#        label = wx.StaticText(self, -1, "Max Pixels")
+#        box.Add(label, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+#        box.Add(self.n_max_ctrl, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+#        self.Bind(floatspin.EVT_FLOATSPIN, self.OnChangeSettings, self.n_max_ctrl)
+#
+#        # end new control
+#
+#        self.partiality_min_ctrl = floatspin.FloatSpin(
+#            parent=self, increment=0.01, digits=3, min_val=0, max_val=1
+#        )
+#        self.partiality_min_ctrl.Bind(wx.EVT_SET_FOCUS, lambda evt: None)
+#        if wx.VERSION >= (2, 9):  # XXX FloatSpin bug in 2.9.2/wxOSX_Cocoa
+#            self.partiality_min_ctrl.SetBackgroundColour(self.GetBackgroundColour())
+#        box = wx.BoxSizer(wx.HORIZONTAL)
+#        self.panel_sizer.Add(box)
+#        label = wx.StaticText(self, -1, "Min partiality")
+#        box.Add(label, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+#        box.Add(self.partiality_min_ctrl, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+#        self.Bind(
+#            floatspin.EVT_FLOATSPIN, self.OnChangeSettings, self.partiality_min_ctrl
+#        )
+#
+#        self.partiality_max_ctrl = floatspin.FloatSpin(
+#            parent=self, increment=0.01, digits=3, min_val=0, max_val=1
+#        )
+#        self.partiality_max_ctrl.Bind(wx.EVT_SET_FOCUS, lambda evt: None)
+#        if wx.VERSION >= (2, 9):  # XXX FloatSpin bug in 2.9.2/wxOSX_Cocoa
+#            self.partiality_max_ctrl.SetBackgroundColour(self.GetBackgroundColour())
+#        box = wx.BoxSizer(wx.HORIZONTAL)
+#        self.panel_sizer.Add(box)
+#        label = wx.StaticText(self, -1, "Max partiality")
+#        box.Add(label, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+#        box.Add(self.partiality_max_ctrl, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+#        self.Bind(
+#            floatspin.EVT_FLOATSPIN, self.OnChangeSettings, self.partiality_max_ctrl
+#        )
+#
+#        ctrls = self.create_controls(
+#            setting="show_rotation_axis", label="Show rotation axis"
+#        )
+#        self.panel_sizer.Add(ctrls[0], 0, wx.ALL, 5)
+#        ctrls = self.create_controls(
+#            setting="show_beam_vector", label="Show beam vector"
+#        )
+#        self.panel_sizer.Add(ctrls[0], 0, wx.ALL, 5)
+#        ctrls = self.create_controls(
+#            setting="show_reciprocal_cell", label="Show reciprocal cell"
+#        )
+#        self.panel_sizer.Add(ctrls[0], 0, wx.ALL, 5)
+#        ctrls = self.create_controls(
+#            setting="label_nearest_point", label="Label nearest point"
+#        )
+#        self.panel_sizer.Add(ctrls[0], 0, wx.ALL, 5)
+#        self.reverse_phi_ctrl = self.create_controls(
+#            setting="reverse_phi", label="Invert rotation axis"
+#        )[0]
+#        self.panel_sizer.Add(self.reverse_phi_ctrl, 0, wx.ALL, 5)
+#
+#        self.Bind(wx.EVT_CHECKBOX, self.OnChangeSettings, self.reverse_phi_ctrl)
+#
+#        self.crystal_frame_tooltip = wx.ToolTip(
+#            "Show the reciprocal lattice(s) in the crystal rather than the laboratory frame"
+#        )
+#        self.crystal_frame_ctrl = self.create_controls(
+#            setting="crystal_frame", label="Show in crystal frame"
+#        )[0]
+#        self.crystal_frame_ctrl.SetToolTip(self.crystal_frame_tooltip)
+#        self.panel_sizer.Add(self.crystal_frame_ctrl, 0, wx.ALL, 5)
+#
+#        self.Bind(wx.EVT_CHECKBOX, self.OnChangeSettings, self.crystal_frame_ctrl)
+#
+#        self.beam_panel_ctrl = floatspin.FloatSpin(
+#            parent=self, min_val=0, increment=1, digits=0
+#        )
+#        self.beam_panel_ctrl.Bind(wx.EVT_SET_FOCUS, lambda evt: None)
+#        if wx.VERSION >= (2, 9):  # XXX FloatSpin bug in 2.9.2/wxOSX_Cocoa
+#            self.beam_panel_ctrl.SetBackgroundColour(self.GetBackgroundColour())
+#        box = wx.BoxSizer(wx.HORIZONTAL)
+#        self.panel_sizer.Add(box)
+#        label = wx.StaticText(self, -1, "Beam centre panel")
+#        box.Add(label, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+#        box.Add(self.beam_panel_ctrl, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+#        self.Bind(floatspin.EVT_FLOATSPIN, self.OnChangeSettings, self.beam_panel_ctrl)
+#
+#        self.beam_fast_ctrl = floatspin.FloatSpin(parent=self, increment=0.01, digits=2)
+#        self.beam_fast_ctrl.Bind(wx.EVT_SET_FOCUS, lambda evt: None)
+#        if wx.VERSION >= (2, 9):  # XXX FloatSpin bug in 2.9.2/wxOSX_Cocoa
+#            self.beam_fast_ctrl.SetBackgroundColour(self.GetBackgroundColour())
+#        box = wx.BoxSizer(wx.HORIZONTAL)
+#        self.panel_sizer.Add(box)
+#        label = wx.StaticText(self, -1, "Beam centre (mm)")
+#        box.Add(label, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+#        box.Add(self.beam_fast_ctrl, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+#        self.Bind(floatspin.EVT_FLOATSPIN, self.OnChangeSettings, self.beam_fast_ctrl)
+#
+#        self.beam_slow_ctrl = floatspin.FloatSpin(parent=self, increment=0.01, digits=2)
+#        self.beam_slow_ctrl.Bind(wx.EVT_SET_FOCUS, lambda evt: None)
+#        if wx.VERSION >= (2, 9):  # XXX FloatSpin bug in 2.9.2/wxOSX_Cocoa
+#            self.beam_slow_ctrl.SetBackgroundColour(self.GetBackgroundColour())
+#        box.Add(self.beam_slow_ctrl, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+#        self.Bind(floatspin.EVT_FLOATSPIN, self.OnChangeSettings, self.beam_slow_ctrl)
+#
+#        self.marker_size_ctrl = floatspin.FloatSpin(
+#            parent=self, increment=1, digits=0, min_val=1
+#        )
+#        self.marker_size_ctrl.Bind(wx.EVT_SET_FOCUS, lambda evt: None)
+#        if wx.VERSION >= (2, 9):  # XXX FloatSpin bug in 2.9.2/wxOSX_Cocoa
+#            self.marker_size_ctrl.SetBackgroundColour(self.GetBackgroundColour())
+#        box = wx.BoxSizer(wx.HORIZONTAL)
+#        self.panel_sizer.Add(box)
+#        label = wx.StaticText(self, -1, "Marker size:")
+#        box.Add(label, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+#        box.Add(self.marker_size_ctrl, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+#        self.Bind(floatspin.EVT_FLOATSPIN, self.OnChangeSettings, self.marker_size_ctrl)
+#
+#        self.btn = SegmentedRadioControl(self, style=SEGBTN_HORIZONTAL)
+#        self.btn.AddSegment("all")
+#        self.btn.AddSegment("indexed")
+#        self.btn.AddSegment("unindexed")
+#        self.btn.AddSegment("integrated")
+#        self.btn.SetSelection(
+#            ["all", "indexed", "unindexed", "integrated"].index(self.settings.display)
+#        )
+#        self.Bind(wx.EVT_RADIOBUTTON, self.OnChangeSettings, self.btn)
+#        self.GetSizer().Add(self.btn, 0, wx.ALL, 5)
+#
+#        self.outlier_btn = SegmentedRadioControl(self, style=SEGBTN_HORIZONTAL)
+#        self.outlier_btn.AddSegment("all")
+#        self.outlier_btn.AddSegment("inliers")
+#        self.outlier_btn.AddSegment("outliers")
+#        self.outlier_btn.SetSelection(
+#            [None, "inliers", "outliers"].index(self.settings.outlier_display)
+#        )
+#        self.Bind(wx.EVT_RADIOBUTTON, self.OnChangeSettings, self.outlier_btn)
+#        self.GetSizer().Add(self.outlier_btn, 0, wx.ALL, 5)
+#
+#    def add_value_widgets(self, sizer):
+#        sizer.Add(
+#            wx.StaticText(self.panel, -1, "Value:"),
+#            0,
+#            wx.ALL | wx.ALIGN_CENTER_VERTICAL,
+#            5,
+#        )
+#        self.value_info = wx.TextCtrl(
+#            self.panel, -1, size=(80, -1), style=wx.TE_READONLY
+#        )
+#        sizer.Add(self.value_info, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+
+# def add_experiments_buttons(self):
+#    n = flex.max(self.parent.reflections_input["id"])
+#    if n <= 0:
+#        self.expt_btn = None
+#        return
+#
+#    box = wx.BoxSizer(wx.VERTICAL)
+#    self.panel_sizer.Add(box)
+#    label = wx.StaticText(self, -1, "Experiment ids:")
+#    box.Add(label, 0, wx.ALL, 5)
+#
+#    self.expt_btn = SegmentedToggleControl(self, style=SEGBTN_HORIZONTAL)
+#    for i in range(-1, n + 1):
+#        self.expt_btn.AddSegment(str(i))
+#        if (
+#            self.settings.experiment_ids is not None
+#            and i in self.settings.experiment_ids
+#        ):
+#            self.expt_btn.SetValue(i + 1, True)
+#
+#    self.expt_btn.Realize()
+#    self.Bind(wx.EVT_TOGGLEBUTTON, self.OnChangeSettings, self.expt_btn)
+#    box.Add(self.expt_btn, 0, wx.ALL, 5)
+
+#    def OnChangeSettings(self, event):
+#        self.settings.d_min = self.d_min_ctrl.GetValue()
+#        self.settings.z_min = self.z_min_ctrl.GetValue()
+#        self.settings.z_max = self.z_max_ctrl.GetValue()
+#        self.settings.n_min = int(self.n_min_ctrl.GetValue())
+#        self.settings.n_max = int(self.n_max_ctrl.GetValue())
+#        self.settings.partiality_min = self.partiality_min_ctrl.GetValue()
+#        self.settings.partiality_max = self.partiality_max_ctrl.GetValue()
+#
+#        old_beam_panel = self.settings.beam_centre_panel
+#        old_beam_centre = self.settings.beam_centre
+#        self.settings.beam_centre_panel = self.beam_panel_ctrl.GetValue()
+#        self.settings.beam_centre = (
+#            self.beam_fast_ctrl.GetValue(),
+#            self.beam_slow_ctrl.GetValue(),
+#        )
+#        self.settings.reverse_phi = self.reverse_phi_ctrl.GetValue()
+#        self.settings.crystal_frame = self.crystal_frame_ctrl.GetValue()
+#        self.settings.marker_size = self.marker_size_ctrl.GetValue()
+#        for i, display in enumerate(("all", "indexed", "unindexed", "integrated")):
+#            if self.btn.values[i]:
+#                self.settings.display = display
+#                break
+#
+#        for i, display in enumerate(("all", "inliers", "outliers")):
+#            if self.outlier_btn.values[i]:
+#                self.settings.outlier_display = display
+#                break
+#
+#        if self.expt_btn is not None:
+#            expt_ids = []
+#            for i in range(len(self.expt_btn.segments)):
+#                if self.expt_btn.GetValue(i):
+#                    expt_ids.append(i - 1)
+#            self.settings.experiment_ids = expt_ids
+#
+#        try:
+#            self.parent.update_settings()
+#        except ValueError:  # Handle beam centre changes, which could fail
+#            self.settings.beam_centre_panel = old_beam_panel
+#            self.settings.beam_centre = old_beam_centre
+#            self.beam_panel_ctrl.SetValue(old_beam_panel)
+#            self.beam_fast_ctrl.SetValue(old_beam_centre[0])
+#            self.beam_slow_ctrl.SetValue(old_beam_centre[1])
+
+
+class RLVWindow:
+    def __init__(self, settings, *args, **kwds):
+        # super().__init__(*args, **kwds)
+        self.settings = settings
+        self.points = flex.vec3_double()
+        self.colors = None
+        self.palette = None
+        self.rotation_axis = None
+        self.beam_vector = None
+        self.recip_latt_vectors = None
+        self.recip_crystal_vectors = None
+        self.flag_show_minimum_covering_sphere = False
+        self.minimum_covering_sphere = None
+        self.field_of_view_y = 0.001
+        # if self.settings.autospin:
+        #    self.autospin_allowed = True
+        #    self.yspin = 1
+        #    self.xspin = 1
+        #    self.autospin = True
+
+    def set_points(self, points):
+        self.points = points
+        self.points_display_list = None
+        if self.minimum_covering_sphere is None:
+            self.update_minimum_covering_sphere()
+
+    def set_points_data(self, reflections):
+        dstar = reflections["rlp"].norms()
+        dstar.set_selected(dstar == 0, 1e-8)
+        self.points_data = {
+            "panel": reflections["panel"],
+            "id": reflections["id"],
+            "xyz": reflections["xyzobs.px.value"],
+            "d_spacing": 1 / dstar,
+        }
+        if "miller_index" in reflections:
+            self.points_data["miller_index"] = reflections["miller_index"]
+
+    def set_colors(self, colors):
+        assert len(colors) == len(self.points)
+        self.colors = colors
+
+    def set_palette(self, palette):
+        self.palette = palette
+
+    def draw_points(self):
+        if self.points_display_list is None:
+            self.points_display_list = gltbx.gl_managed.display_list()
+            self.points_display_list.compile()
+            gl.glLineWidth(1)
+            if self.colors is None:
+                self.colors = flex.vec3_double(len(self.points), (1, 1, 1))
+            for point, color in zip(self.points, self.colors):
+                self.draw_cross_at(point, color=color)
+            self.points_display_list.end()
+        self.points_display_list.call()
+
+    def set_rotation_axis(self, axis):
+        self.rotation_axis = axis
+
+    def set_beam_vector(self, beam):
+        self.beam_vector = beam
+
+    def set_reciprocal_lattice_vectors(self, vectors_per_crystal):
+        self.recip_latt_vectors = vectors_per_crystal
+
+    def set_reciprocal_crystal_vectors(self, vectors_per_crystal):
+        self.recip_crystal_vectors = vectors_per_crystal
+
+    # --- user input and settings
+    # def update_settings(self):
+    #    self.points_display_list = None
+    #    self.Refresh()
+
+    def update_minimum_covering_sphere(self):
+        n_points = min(1000, self.points.size())
+        isel = flex.random_permutation(self.points.size())[:n_points]
+        self.minimum_covering_sphere = minimum_covering_sphere(self.points.select(isel))
+
+    def draw_cross_at(self, xyz, color=(1, 1, 1), f=None):
+        (x, y, z) = xyz
+        if f is None:
+            f = 0.01 * self.settings.marker_size
+        wx_viewer.show_points_and_lines_mixin.draw_cross_at(
+            self, (x, y, z), color=color, f=f
+        )
+
+    # def DrawGL(self):
+    #    wx_viewer.show_points_and_lines_mixin.DrawGL(self)
+    #    if self.rotation_axis is not None and self.settings.show_rotation_axis:
+    #        self.draw_axis(self.rotation_axis, "phi")
+    #    if self.beam_vector is not None and self.settings.show_beam_vector:
+    #        self.draw_axis(self.beam_vector, "beam")
+
+    def draw_cells(self):
+        """Create a list of lines corresponding to reciprocal unit cells"""
+
+        lines = []
+        colors = []
+        if self.settings.show_reciprocal_cell:
+            # if we don't have one sort of vector we don't have the other either
+            vectors = self.recip_latt_vectors
+            if self.settings.crystal_frame:
+                vectors = self.recip_crystal_vectors
+
+            if vectors:
+                for i, axes in enumerate(vectors):
+                    if self.settings.experiment_ids:
+                        if i not in self.settings.experiment_ids:
+                            continue
+                    j = (i + 1) % self.palette.size()
+                    colors.extend([self.palette[j]] * 12)
+                    lines.extend(self.cell_edges(axes))
+        colors = np.array(colors)
+        return lines, colors
+
+        # if self.settings.label_nearest_point:
+        #    self.label_nearest_point()
+
+        # self.GetParent().update_statusbar()
+
+    # def draw_axis(self, axis, label):
+    #    if self.minimum_covering_sphere is None:
+    #        self.update_minimum_covering_sphere()
+    #    s = self.minimum_covering_sphere
+    #    scale = max(max(s.box_max()), abs(min(s.box_min())))
+    #    #gltbx.fonts.ucs_bitmap_8x13.setup_call_lists()
+    #    #gl.glDisable(gl.GL_LIGHTING)
+    #    #if self.settings.black_background:
+    #    #    gl.glColor3f(1.0, 1.0, 1.0)
+    #    #else:
+    #    #    gl.glColor3f(0.0, 0.0, 0.0)
+    #    #gl.glLineWidth(1.0)
+    #    #gl.glBegin(gl.GL_LINES)
+    #    gl.glVertex3f(0.0, 0.0, 0.0)
+    #    gl.glVertex3f(axis[0] * scale, axis[1] * scale, axis[2] * scale)
+    #    gl.glEnd()
+    #    gl.glRasterPos3f(
+    #        0.5 + axis[0] * scale, 0.2 + axis[1] * scale, 0.2 + axis[2] * scale
+    #    )
+    #    gltbx.fonts.ucs_bitmap_8x13.render_string(label)
+    #    gl.glEnable(gl.GL_LINE_STIPPLE)
+    #    gl.glLineStipple(4, 0xAAAA)
+    #    gl.glBegin(gl.GL_LINES)
+    #    gl.glVertex3f(0.0, 0.0, 0.0)
+    #    gl.glVertex3f(-axis[0] * scale, -axis[1] * scale, -axis[2] * scale)
+    #    gl.glEnd()
+    #    gl.glDisable(gl.GL_LINE_STIPPLE)
+
+    def cell_edges(self, axes):
+        astar, bstar, cstar = axes[0], axes[1], axes[2]
+        farpoint = astar + bstar + cstar
+
+        lines = [
+            np.array([[0, 0, 0], [*astar.elems]]),
+            np.array([[0, 0, 0], [*bstar.elems]]),
+            np.array([[0, 0, 0], [*cstar.elems]]),
+            np.array([[*astar.elems], [*(astar + bstar).elems]]),
+            np.array([[*astar.elems], [*(astar + cstar).elems]]),
+            np.array([[*bstar.elems], [*(bstar + astar).elems]]),
+            np.array([[*bstar.elems], [*(bstar + cstar).elems]]),
+            np.array([[*cstar.elems], [*(cstar + astar).elems]]),
+            np.array([[*cstar.elems], [*(cstar + bstar).elems]]),
+            np.array([[*farpoint.elems], [*(farpoint - astar).elems]]),
+            np.array([[*farpoint.elems], [*(farpoint - bstar).elems]]),
+            np.array([[*farpoint.elems], [*(farpoint - cstar).elems]]),
+        ]
+        return lines
+
+    def label_nearest_point(self):
+        ann = AnnAdaptorSelfInclude(self.points.as_double(), 3)
+        ann.query(self.rotation_center)
+        i = ann.nn[0]
+        gltbx.fonts.ucs_bitmap_8x13.setup_call_lists()
+        gl.glDisable(gl.GL_LIGHTING)
+        gl.glColor3f(1.0, 1.0, 1.0)
+        gl.glLineWidth(1.0)
+        xyz = self.points_data["xyz"][i]
+        exp_id = self.points_data["id"][i]
+        panel = self.points_data["panel"][i]
+        d_spacing = self.points_data["d_spacing"][i]
+        label = (
+            f"id: {exp_id}; panel: {panel}\n"
+            f"xyz: {xyz[0]:.1f} {xyz[1]:.1f} {xyz[2]:.1f}\n"
+            f"res: {d_spacing:.2f} Angstrom"
+        )
+        if "miller_index" in self.points_data and exp_id != -1:
+            hkl = self.points_data["miller_index"][i]
+            label += f"\nhkl: {hkl}"
+        line_spacing = round(gltbx.fonts.ucs_bitmap_8x13.height())
+        for j, string in enumerate(label.splitlines()):
+            gl.glRasterPos3f(*self.points[i])
+            gl.glBitmap(0, 0, 0.0, 0.0, line_spacing, -j * line_spacing, b" ")
+            gltbx.fonts.ucs_bitmap_8x13.render_string(string)
+
+    # def rotate_view(self, x1, y1, x2, y2, shift_down=False, scale=0.1):
+    #    super().rotate_view(x1, y1, x2, y2, shift_down=shift_down, scale=scale)
+
+    # def OnLeftUp(self, event):
+    #    self.was_dragged = True
+    #    super().OnLeftUp(event)
+
+    # def initialize_modelview(self, eye_vector=None, angle=None):
+    #    super().initialize_modelview(eye_vector=eye_vector, angle=angle)
+    #    self.rotation_center = (0, 0, 0)
+    #    self.move_to_center_of_viewport(self.rotation_center)
+    #    if self.settings.model_view_matrix is not None:
+    #        gl.glLoadMatrixd(self.settings.model_view_matrix)

--- a/dgw/rlv/viewer.py
+++ b/dgw/rlv/viewer.py
@@ -55,15 +55,30 @@ def rlv_display(
 
 
 class ReciprocalLatticeViewer(Render3d):
-    def __init__(self, parent, id, title, size, settings=None, *args, **kwds):
+    def __init__(self, parent, id, title, size, settings, napari_viewer, *args, **kwds):
         Render3d.__init__(self, settings=settings)
 
         self.viewer = RLVWindow(
             settings=self.settings,
         )
 
-    def add_to_napari(self, napari_viewer):
-        """Add the layers data to a napari viewer"""
+        self.napari_viewer = napari_viewer
+
+    def add_rlv_widgets(self):
+        # Add the rlv_display widget and set values and limits
+        self.napari_viewer.window.add_dock_widget(rlv_display, name="rlv display")
+        rlv_display.marker_size.value = self.settings.marker_size
+        rlv_display.d_min.value = self.settings.d_min
+        rlv_display.d_min.min = self.settings.d_min
+        rlv_display.z_min.value = self.settings.z_min
+        rlv_display.z_min.min = self.settings.z_min
+        rlv_display.z_min.max = self.settings.z_max
+        rlv_display.z_max.value = self.settings.z_max
+        rlv_display.z_max.min = self.settings.z_min
+        rlv_display.z_max.max = self.settings.z_max
+
+    def add_layers(self):
+        """Add the layers data to the napari viewer"""
 
         # Get the reciprocal cells for drawing
         cells = self.viewer.draw_cells()
@@ -108,7 +123,7 @@ class ReciprocalLatticeViewer(Render3d):
             # property values are displayed in the status bar, when the relevant
             # layer is selected
 
-            relps_layer = napari_viewer.add_points(
+            relps_layer = self.napari_viewer.add_points(
                 points,
                 properties=point_properties,
                 face_color=colors,
@@ -120,7 +135,7 @@ class ReciprocalLatticeViewer(Render3d):
             # Add the cell as a shapes layer, if it exists
             cell = cells.get(exp_id)
             if cell:
-                cell_layer = napari_viewer.add_shapes(
+                cell_layer = self.napari_viewer.add_shapes(
                     cell.lines,
                     shape_type="line",
                     edge_width=0.5,
@@ -141,7 +156,7 @@ class ReciprocalLatticeViewer(Render3d):
             [[0, 0, 0], [axis[0] * scale, axis[1] * scale, axis[2] * scale]]
         )
 
-        axis_layer = napari_viewer.add_shapes(
+        axis_layer = self.napari_viewer.add_shapes(
             [
                 axis_line,
             ],
@@ -150,18 +165,6 @@ class ReciprocalLatticeViewer(Render3d):
             edge_color="white",
             name="axis",
         )
-
-        # Add the rlv_display widget and set values and limits
-        napari_viewer.window.add_dock_widget(rlv_display, name="rlv display")
-        rlv_display.marker_size.value = self.settings.marker_size
-        rlv_display.d_min.value = self.settings.d_min
-        rlv_display.d_min.min = self.settings.d_min
-        rlv_display.z_min.value = self.settings.z_min
-        rlv_display.z_min.min = self.settings.z_min
-        rlv_display.z_min.max = self.settings.z_max
-        rlv_display.z_max.value = self.settings.z_max
-        rlv_display.z_max.min = self.settings.z_min
-        rlv_display.z_max.max = self.settings.z_max
 
         return
 


### PR DESCRIPTION
Known issues:

- At low zoom the points fade out rather abruptly, which means it is not as easy as with `dials.rlv` to get a good overview image
- Text labels (`a*`, `b*`, c`*` and `phi`) are missing due to a bug, though a workaround has been suggested (https://forum.image.sc/t/display-text-for-shapes-in-3d/66677/2)
- The relp status panel is a bit crappy. It could do with display widgets for each value, not just one `Label`. Also, one has to select the relevant points layer from the layer list first and then select the point of interest (however information about the nearest point is also displayed in the lower status bar)
- Missing some features of `dials.rlv` (min/max pixels, min/max partiality, beam vector, beam centre controls) but these are not things I generally find useful