### PR TITLE
How to make a `std::vector` of arrays?

### DIFF
--- a/dgw/cctbx_cpp_examples/array_gotchas.h
+++ b/dgw/cctbx_cpp_examples/array_gotchas.h
@@ -81,19 +81,21 @@ private:
   scitbx::af::versa<double, scitbx::af::c_grid<2>> array_data_;
 };
 
-class VectorOfArrays {
+class BadVectorOfArrays {
 public:
-  VectorOfArrays() {}
+  BadVectorOfArrays() {}
 
-  void add_array_to_vector(scitbx::af::const_ref<float> const &values) {
+  // Use of const_ref here means the lifetime is determined externally, and
+  // when we later access the values we get undefined behaviour
+  void add_array_to_vector(scitbx::af::const_ref<double> const &values) {
     array_cache_.push_back(values);
   }
 
-  float get_sum() {
+  double get_sum() {
 
-    float total = 0.0;
+    double total = 0.0;
     for (std::size_t i = 0; i < array_cache_.size(); i++) {
-      scitbx::af::const_ref<float> &col = array_cache_[i];
+      scitbx::af::const_ref<double> &col = array_cache_[i];
       for (std::size_t j = 0; j < col.size(); j++) {
         total += col[j];
       }
@@ -102,7 +104,32 @@ public:
   }
 
 private:
-  std::vector<scitbx::af::const_ref<float>> array_cache_;
+  std::vector<scitbx::af::const_ref<double>> array_cache_;
+};
+
+class VectorOfArrays {
+public:
+  VectorOfArrays() {}
+
+  // The version using shared works fine
+  void add_array_to_vector(scitbx::af::shared<double> const &values) {
+    array_cache_.push_back(values);
+  }
+
+  double get_sum() {
+
+    double total = 0.0;
+    for (std::size_t i = 0; i < array_cache_.size(); i++) {
+      scitbx::af::shared<double> &col = array_cache_[i];
+      for (std::size_t j = 0; j < col.size(); j++) {
+        total += col[j];
+      }
+    }
+    return total;
+  }
+
+private:
+  std::vector<scitbx::af::shared<double>> array_cache_;
 };
 
 } // namespace examples

--- a/dgw/cctbx_cpp_examples/array_gotchas.h
+++ b/dgw/cctbx_cpp_examples/array_gotchas.h
@@ -12,6 +12,8 @@
 #ifndef DIALS_SCRATCH_EXAMPLES_ARRAY_GOTCHAS_H
 #define DIALS_SCRATCH_EXAMPLES_ARRAY_GOTCHAS_H
 
+#include <vector>
+
 #include <scitbx/array_family/ref.h>
 #include <scitbx/array_family/shared.h>
 
@@ -77,6 +79,30 @@ public:
 private:
   // Store the array as versa<double>
   scitbx::af::versa<double, scitbx::af::c_grid<2>> array_data_;
+};
+
+class VectorOfArrays {
+public:
+  VectorOfArrays() {}
+
+  void add_array_to_vector(scitbx::af::const_ref<float> const &values) {
+    array_cache_.push_back(values);
+  }
+
+  float get_sum() {
+
+    float total = 0.0;
+    for (std::size_t i = 0; i < array_cache_.size(); i++) {
+      scitbx::af::const_ref<float> &col = array_cache_[i];
+      for (std::size_t j = 0; j < col.size(); j++) {
+        total += col[j];
+      }
+    }
+    return total;
+  }
+
+private:
+  std::vector<scitbx::af::const_ref<float>> array_cache_;
 };
 
 } // namespace examples

--- a/dgw/cctbx_cpp_examples/array_gotchas.py
+++ b/dgw/cctbx_cpp_examples/array_gotchas.py
@@ -130,7 +130,7 @@ def demo_cannot_pass_versa_from_python():
     print("This works, and the data can be passed back to Python via af::versa")
 
 
-def demo_vector_of_arrays_segfault():
+def demo_vector_of_arrays_segfault(n_arrays=10, arr_len=10000):
 
     from dials_scratch_cctbx_cpp_examples_ext import VectorOfArrays
     from cctbx.array_family import flex
@@ -139,8 +139,8 @@ def demo_vector_of_arrays_segfault():
 
     # Make some float arrays to add to the cache.
     py_sum = 0
-    for i in range(10):
-        arr = flex.random_double(10000).as_float()
+    for i in range(n_arrays):
+        arr = flex.random_double(int(arr_len)).as_float()
         py_sum += flex.sum(arr)
         voa.add_array_to_vector(arr)
 

--- a/dgw/cctbx_cpp_examples/array_gotchas.py
+++ b/dgw/cctbx_cpp_examples/array_gotchas.py
@@ -130,6 +130,27 @@ def demo_cannot_pass_versa_from_python():
     print("This works, and the data can be passed back to Python via af::versa")
 
 
+def demo_vector_of_arrays_segfault():
+
+    from dials_scratch_cctbx_cpp_examples_ext import VectorOfArrays
+    from cctbx.array_family import flex
+
+    voa = VectorOfArrays()
+
+    # Make some float arrays to add to the cache.
+    py_sum = 0
+    for i in range(10):
+        arr = flex.random_double(10000).as_float()
+        py_sum += flex.sum(arr)
+        voa.add_array_to_vector(arr)
+
+    # Attempt to print the values
+    print(py_sum)
+    print(voa.get_sum())
+
+    # Values are different, and if the cache is big enough it segfaults :-/
+
+
 if __name__ == "__main__":
 
     runner(demo_no_converter_for_const_ref)

--- a/dgw/cctbx_cpp_examples/array_gotchas.py
+++ b/dgw/cctbx_cpp_examples/array_gotchas.py
@@ -130,17 +130,25 @@ def demo_cannot_pass_versa_from_python():
     print("This works, and the data can be passed back to Python via af::versa")
 
 
-def demo_vector_of_arrays_segfault(n_arrays=10, arr_len=10000):
+def demo_vector_of_arrays(
+    n_arrays=10, arr_len=10000, use_bad_version_that_may_segfault=False
+):
+    """Demonstrate the use of a class that stores a cache of scitbx double
+    arrays using a std::vector. The right way to do that is to pass the arrays
+    in as shared. The bad version using const_ref may segfault."""
 
-    from dials_scratch_cctbx_cpp_examples_ext import VectorOfArrays
+    from dials_scratch_cctbx_cpp_examples_ext import VectorOfArrays, BadVectorOfArrays
     from cctbx.array_family import flex
 
-    voa = VectorOfArrays()
+    if use_bad_version_that_may_segfault:
+        voa = BadVectorOfArrays()
+    else:
+        voa = VectorOfArrays()
 
     # Make some float arrays to add to the cache.
     py_sum = 0
     for i in range(n_arrays):
-        arr = flex.random_double(int(arr_len)).as_float()
+        arr = flex.random_double(int(arr_len))
         py_sum += flex.sum(arr)
         voa.add_array_to_vector(arr)
 
@@ -148,7 +156,11 @@ def demo_vector_of_arrays_segfault(n_arrays=10, arr_len=10000):
     print(py_sum)
     print(voa.get_sum())
 
-    # Values are different, and if the cache is big enough it segfaults :-/
+    # For the BadVectorOfArrays, the values are different, and if the cache is
+    # big enough it segfaults :-/
+
+    assert py_sum == voa.get_sum()
+    # We only get here with the good version
 
 
 if __name__ == "__main__":
@@ -156,3 +168,4 @@ if __name__ == "__main__":
     runner(demo_no_converter_for_const_ref)
     runner(demo_data_loss_with_const_ref_storage)
     runner(demo_cannot_pass_versa_from_python)
+    runner(demo_vector_of_arrays)

--- a/dgw/cctbx_cpp_examples/boost_python/array_gotchas.cc
+++ b/dgw/cctbx_cpp_examples/boost_python/array_gotchas.cc
@@ -46,6 +46,11 @@ void export_two_dimensional_array() {
 
 void export_vector_of_arrays() {
   // Broken version (segfaults)
+  class_<BadVectorOfArrays>("BadVectorOfArrays")
+      .def("add_array_to_vector", &BadVectorOfArrays::add_array_to_vector)
+      .def("get_sum", &BadVectorOfArrays::get_sum);
+
+  // Working version
   class_<VectorOfArrays>("VectorOfArrays")
       .def("add_array_to_vector", &VectorOfArrays::add_array_to_vector)
       .def("get_sum", &VectorOfArrays::get_sum);

--- a/dgw/cctbx_cpp_examples/boost_python/array_gotchas.cc
+++ b/dgw/cctbx_cpp_examples/boost_python/array_gotchas.cc
@@ -44,6 +44,13 @@ void export_two_dimensional_array() {
       .def("get_array_data", &TwoDimensionalArray::get_array_data);
 }
 
+void export_vector_of_arrays() {
+  // Broken version (segfaults)
+  class_<VectorOfArrays>("VectorOfArrays")
+      .def("add_array_to_vector", &VectorOfArrays::add_array_to_vector)
+      .def("get_sum", &VectorOfArrays::get_sum);
+}
+
 } // namespace boost_python
 } // namespace examples
 } // namespace dials_scratch

--- a/dgw/cctbx_cpp_examples/boost_python/examples_ext.cc
+++ b/dgw/cctbx_cpp_examples/boost_python/examples_ext.cc
@@ -14,6 +14,7 @@ void export_print_array();
 void export_print_array_head();
 void export_create_sparse_matrix();
 void export_mat_sum();
+void export_vector_of_arrays();
 
 BOOST_PYTHON_MODULE(dials_scratch_cctbx_cpp_examples_ext) {
   export_bad_bucket();
@@ -22,6 +23,7 @@ BOOST_PYTHON_MODULE(dials_scratch_cctbx_cpp_examples_ext) {
   export_print_array_head();
   export_create_sparse_matrix();
   export_mat_sum();
+  export_vector_of_arrays();
 }
 
 } // namespace boost_python


### PR DESCRIPTION
Here I am trying to make a class that stores a cache of `af::const_ref<float>` arrays, by adding them to a `std::vector`. I am getting something wrong with references / object lifetimes or something, because when I get the values out of the cache they are either not as expected, or I get a segfault if the cache is large enough.

Example:
```
Python 3.10.8 | packaged by conda-forge | (main, Nov 22 2022, 08:26:04) [GCC 10.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from dials_scratch.dgw.cctbx_cpp_examples.array_gotchas import demo_vector_of_arrays_segfault
>>> demo_vector_of_arrays_segfault(10,100)
<frozen importlib._bootstrap>:241: RuntimeWarning: to-Python converter for dials_scratch::examples::TwoDimensionalArray already registered; second conversion method ignored.
490.7963523864746
476.9270324707031
>>> demo_vector_of_arrays_segfault(10,10e5)
4999657.15625
Segmentation fault (core dumped)
```
In the first call the arrays are small (100 elements), but the sum of values in the cache is not as expected. In the second case the arrays are large (10e5 elements) and the code segfaults.

Ignore the `RuntimeWarning`, that's something unrelated...